### PR TITLE
Add `parse_oembeds()` method to Shortcode class

### DIFF
--- a/inc/shortcodes/class-facebook.php
+++ b/inc/shortcodes/class-facebook.php
@@ -4,6 +4,17 @@ namespace Shortcake_Bakery\Shortcodes;
 
 class Facebook extends Shortcode {
 
+	// Our matching URL patterns for Facebook
+	private static $url_patterns = array(
+		'#https?://(www)?\.facebook\.com/[^/]+/posts/[\d]+#',
+		'#https?://(www)?\.facebook\.com\/video\.php\?v=[\d]+#',
+		'#https?:\/\/www?\.facebook\.com\/+.*?\/videos\/[\d]+\/#',
+		'#https?://(www)?\.facebook\.com\/permalink\.php\?story_fbid=[\d]+&id=[\d]+#',
+		'#https?:\/\/www?\.facebook\.com\/.*?\/photos\/([^/]+)/([\d])+/#',
+		'#https?:\/\/www?\.facebook\.com\/.*?\/videos\/([^/]+)/([\d])+/#',
+		'#https?:\/\/www?\.facebook\.com\/groups\/([\d])+\/permalink/([\d])+/?#',
+	);
+
 	public static function get_shortcode_ui_args() {
 		return array(
 			'label'          => esc_html__( 'Facebook', 'shortcake-bakery' ),
@@ -52,29 +63,43 @@ class Facebook extends Shortcode {
 
 	public static function reversal( $content ) {
 
-		if ( false === stripos( $content, '<script' ) ) {
-			return $content;
+		if ( false !== stripos( $content, '<script' ) ) {
+
+			/* Pattern for normal Facebook embeds */
+			if ( preg_match_all( '#<div id="fb-root"></div><script>[^<]+</script><div class="fb-post" [^>]+href=[\'\"]([^\'\"]+)[\'\"].+</div>(</div>)?#', $content, $matches ) ) {
+				$replacements = array();
+				$shortcode_tag = self::get_shortcode_tag();
+				foreach ( $matches[0] as $key => $value ) {
+					$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[1][ $key ] ) . '"]';
+				}
+				$content = self::make_replacements_to_content( $content, $replacements );
+			}
+
+			/* Pattern for Facebook video embeds */
+			if ( preg_match_all( '#<div id="fb-root"><\/div><script>[^<]+<\/script><div class="fb-video" [^>]+href=[\'\"][^\'\"]+[\'\"]><div class="fb-xfbml-parse-ignore"><blockquote cite=[\'\"][^\'\"]+[\'\"]><a href=[\'\"]([^\'\"]+)[\'\"]+.*?<\/div><\/div>?#', $content, $matches ) ) {
+				$replacements = array();
+				$shortcode_tag = self::get_shortcode_tag();
+				foreach ( $matches[0] as $key => $value ) {
+					$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( 'https://www.facebook.com' . $matches[1][ $key ] ) . '"]';
+				}
+				$content = self::make_replacements_to_content( $content, $replacements );
+			}
 		}
 
-		/* Pattern for normal Facebook embeds */
-		if ( preg_match_all( '#<div id="fb-root"></div><script>[^<]+</script><div class="fb-post" [^>]+href=[\'\"]([^\'\"]+)[\'\"].+</div>(</div>)?#', $content, $matches ) ) {
+		/* Pattern for single-line oEmbed-style links */
+		if ( $oembed_matches = self::parse_oembeds( $content ) ) {
 			$replacements = array();
 			$shortcode_tag = self::get_shortcode_tag();
-			foreach ( $matches[0] as $key => $value ) {
-				$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[1][ $key ] ) . '"]';
+			foreach ( $oembed_matches as $line => $url ) {
+				foreach ( self::$url_patterns as $regex ) {
+					if ( preg_match( $regex, $url ) ) {
+						$replacements[ $line ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $url ) . '"]';
+					}
+				}
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
 		}
 
-		/* Pattern for Facebook video embeds */
-		if ( preg_match_all( '#<div id="fb-root"><\/div><script>[^<]+<\/script><div class="fb-video" [^>]+href=[\'\"][^\'\"]+[\'\"]><div class="fb-xfbml-parse-ignore"><blockquote cite=[\'\"][^\'\"]+[\'\"]><a href=[\'\"]([^\'\"]+)[\'\"]+.*?<\/div><\/div>?#', $content, $matches ) ) {
-			$replacements = array();
-			$shortcode_tag = self::get_shortcode_tag();
-			foreach ( $matches[0] as $key => $value ) {
-				$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( 'https://www.facebook.com' . $matches[1][ $key ] ) . '"]';
-			}
-			$content = self::make_replacements_to_content( $content, $replacements );
-		}
 		return $content;
 	}
 
@@ -88,19 +113,9 @@ class Facebook extends Shortcode {
 		// See https://core.trac.wordpress.org/ticket/11311
 		$attrs['url'] = str_replace( '&amp;', '&', $attrs['url'] );
 
-		// Our matching URL patterns for Facebook
-		$facebook_regex = array(
-			'#https?://(www)?\.facebook\.com/[^/]+/posts/[\d]+#',
-			'#https?://(www)?\.facebook\.com\/video\.php\?v=[\d]+#',
-			'#https?:\/\/www?\.facebook\.com\/+.*?\/videos\/[\d]+\/#',
-			'#https?://(www)?\.facebook\.com\/permalink\.php\?story_fbid=[\d]+&id=[\d]+#',
-			'#https?:\/\/www?\.facebook\.com\/.*?\/photos\/([^/]+)/([\d])+/#',
-			'#https?:\/\/www?\.facebook\.com\/.*?\/videos\/([^/]+)/([\d])+/#',
-			'#https?:\/\/www?\.facebook\.com\/groups\/([\d])+\/permalink/([\d])+/?#',
-			);
 
 		$match = false;
-		foreach ( $facebook_regex as $regex ) {
+		foreach ( self::$url_patterns as $regex ) {
 			if ( preg_match( $regex, $attrs['url'] ) ) {
 				$match = true;
 			}

--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -80,6 +80,28 @@ abstract class Shortcode {
 	}
 
 	/**
+	 * Parse a string of content for any oembeds that can be potentially reversed.
+	 *
+	 * @param string $content
+	 * @return array|false An array with the full lines matched as keys, and the URLs as values
+	 */
+	protected static function parse_oembeds( $content ) {
+		if ( false === stripos( $content, 'http' ) ) {
+			return false;
+		}
+
+		if ( preg_match_all( '#^(\s*)(https?://[^\s"]+)(\s*)$#im', $content, $matches, PREG_SET_ORDER ) ) {
+			$matched_lines = array();
+			foreach ( $matches as $matched_line ) {
+				$matched_lines[ $matched_line[0] ] = $matched_line[2];
+			}
+			return $matched_lines;
+		} else {
+			return false;
+		}
+	}
+
+	/**
 	 * Parse a string of content for a given tag name.
 	 *
 	 * @param string $content

--- a/tests/test-facebook-shortcode.php
+++ b/tests/test-facebook-shortcode.php
@@ -72,6 +72,7 @@ EOT;
 
 		<div id="fb-root"></div><script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.3"; fjs.parentNode.insertBefore(js, fjs);}(document, 'script', 'facebook-jssdk'));</script><div class="fb-video" data-allowfullscreen="1" data-href="/coreycf/videos/vb.100001257008891/953479961370562/?type=1"><div class="fb-xfbml-parse-ignore"><blockquote cite="/coreycf/videos/953479961370562/"><a href="/coreycf/videos/953479961370562/"></a><p>Here&#039;s the free styling he put on lol Brent John Janis Franklin Sioux Bob Nate Badmilk</p>Posted by <a href="https://www.facebook.com/coreycf">Corey James</a> on Saturday, June 27, 2015</blockquote></div></div>
 
+https://www.facebook.com/coreycf/videos/953479961370562/
 		bananas after
 EOT;
 		$transformed_content = wp_filter_post_kses( $old_content );
@@ -97,6 +98,27 @@ EOT;
 		$this->assertContains( 'apples before', $transformed_content );
 		$this->assertContains( 'bananas after', $transformed_content );
 
+	}
+
+	public function test_oembed_reversals() {
+
+		$old_content = <<<EOT
+
+		apples before
+
+		https://www.facebook.com/RichardBranson/photos/a.10151193550160872.451061.31325960871/10151193550380872/?type=1
+
+https://www.facebook.com/coreycf/videos/953479961370562/
+
+		bananas after
+EOT;
+
+		$transformed_content = wp_filter_post_kses( $old_content );
+		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
+		$this->assertContains( '[facebook url="https://www.facebook.com/RichardBranson/photos/a.10151193550160872.451061.31325960871/10151193550380872/?type=1"]', $transformed_content );
+		$this->assertContains( '[facebook url="https://www.facebook.com/coreycf/videos/953479961370562/"]', $transformed_content );
+		$this->assertContains( 'apples before', $transformed_content );
+		$this->assertContains( 'bananas after', $transformed_content );
 	}
 
 }


### PR DESCRIPTION
Adds a new method to the base class `Shortcode::parse_oembeds()`, which
behaves basically the same way that `parse_iframes()` and `parse_scripts()`
do: it returns an array of all URLs found in the content string, with
the full line matched as the keys, and the matched URL as the values.
Individual shortcode classes can then match the URLs against their own
known patterns, and "reverse" these oembed-style links to post elements.

See #5