### PR TITLE
Pass post ID into embed reversal endpoint, allow for filtering response

### DIFF
--- a/assets/js/build/shortcake-bakery-admin.js
+++ b/assets/js/build/shortcake-bakery-admin.js
@@ -30,6 +30,7 @@ var addEmbedController = wp.media.controller.State.extend({
 
 		var promise = jQuery.post(ajaxurl + '?action=shortcake_bakery_embed_reverse', {
 			custom_embed_code: this.props.get( 'custom_embed_code' ),
+			post_id: wp.media.view.settings.post.id,
 			_wpnonce: ShortcakeBakery.nonces.customEmbedReverse
 		});
 

--- a/assets/js/src/addEmbed/controller.js
+++ b/assets/js/src/addEmbed/controller.js
@@ -28,6 +28,7 @@ var addEmbedController = wp.media.controller.State.extend({
 
 		var promise = jQuery.post(ajaxurl + '?action=shortcake_bakery_embed_reverse', {
 			custom_embed_code: this.props.get( 'custom_embed_code' ),
+			post_id: wp.media.view.settings.post.id,
 			_wpnonce: ShortcakeBakery.nonces.customEmbedReverse
 		});
 

--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -162,16 +162,27 @@ class Shortcake_Bakery {
 			exit;
 		}
 		check_ajax_referer( 'embed-reverse', '_wpnonce' );
+		$post_id = intval( $_POST['post_id'] );
 		$provided_embed_code = wp_unslash( $_POST['custom_embed_code'] );
 		$result = $this->reverse_embed( $provided_embed_code );
+
+		/**
+		 * Hook to transform the embed reversal response before returning it to the editor.
+		 *
+		 * @param array Return value of `reverse_embed()`
+		 * @param string Original string provided
+		 * @param int Post ID
+		 */
+		$result = apply_filters( 'shortcake_bakery_embed_reversal', $result, $provided_embed_code, $post_id );
 
 		/*
 		 * Fired whenever an embed code is reversed through Ajax action.
 		 *
 		 * @param array Return value of `reverse_embed()`
 		 * @param string Original string provided
+		 * @param int Post ID
 		 */
-		do_action( 'shortcake_bakery_reversed_embed', $result, $provided_embed_code );
+		do_action( 'shortcake_bakery_reversed_embed', $result, $provided_embed_code, $post_id );
 
 		wp_send_json( $result );
 		exit;


### PR DESCRIPTION
When posting an inserted embed code to the Ajax endpoint, we should also
send the current post ID, so that it is available as additional context
to the "reversed_embed" action.

This also introduces a filter on "shortcake_bakery_embed_reversal", so
that it's possible to filter the result of reversing an embed code. The
idea is that this can be used to implement a system of protected embeds,
or some other way of handling embed codes which don't match one of the
defined post elements.

See #154.