### PR TITLE
Add filter for shortcode UI args for all bakery shortcakes

### DIFF
--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -72,8 +72,7 @@ class Shortcake_Bakery {
 			$this->registered_shortcodes[ $shortcode_tag ] = $class;
 			add_shortcode( $shortcode_tag, array( $this, 'do_shortcode_callback' ) );
 			$class::setup_actions();
-			$ui_args = apply_filters( 'shortcake_bakery_global_ui_args', $class::get_shortcode_ui_args() );
-			$ui_args = apply_filters( "shortcake_bakery_{$shortcode_tag}_ui_args", $ui_args );
+			$ui_args = apply_filters( 'shortcake_bakery_ui_args', $class::get_shortcode_ui_args(), $shortcode_tag );
 			if ( ! empty( $ui_args ) && function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
 				shortcode_ui_register_for_shortcode( $shortcode_tag, $ui_args );
 			}

--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -72,7 +72,7 @@ class Shortcake_Bakery {
 			$this->registered_shortcodes[ $shortcode_tag ] = $class;
 			add_shortcode( $shortcode_tag, array( $this, 'do_shortcode_callback' ) );
 			$class::setup_actions();
-			$ui_args = apply_filters( 'shortcake_bakery_ui_args', $class::get_shortcode_ui_args(), $shortcode_tag );
+			$ui_args = apply_filters( 'shortcake_bakery_shortcode_ui_args', $class::get_shortcode_ui_args(), $shortcode_tag );
 			if ( ! empty( $ui_args ) && function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
 				shortcode_ui_register_for_shortcode( $shortcode_tag, $ui_args );
 			}

--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -72,7 +72,8 @@ class Shortcake_Bakery {
 			$this->registered_shortcodes[ $shortcode_tag ] = $class;
 			add_shortcode( $shortcode_tag, array( $this, 'do_shortcode_callback' ) );
 			$class::setup_actions();
-			$ui_args = $class::get_shortcode_ui_args();
+			$ui_args = apply_filters( 'shortcake_bakery_global_ui_args', $class::get_shortcode_ui_args() );
+			$ui_args = apply_filters( "shortcake_bakery_{$shortcode_tag}_ui_args", $ui_args );
 			if ( ! empty( $ui_args ) && function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
 				shortcode_ui_register_for_shortcode( $shortcode_tag, $ui_args );
 			}


### PR DESCRIPTION
Gives the user the ability to add UI args to all shortcodes registered via Bakery or on a per-shortcode basis, without having to override the original class completely.

Rendering the new UI args can be handled by filtering `shortcake_bakery_shortcode_callback`.