### PR TITLE
Set default indent size to 4 spaces in EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+indent_size = 4
 
 [readme.txt,*.md,*.markdown]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Default `indent_size` was missing from `.editorconfig`.

See also https://github.com/wp-shortcake/image-shortcake/pull/64