### PR TITLE
Allow for referencing instagram embed using subdomains

### DIFF
--- a/inc/shortcodes/class-instagram.php
+++ b/inc/shortcodes/class-instagram.php
@@ -60,9 +60,9 @@ class Instagram extends Shortcode {
 			return '';
 		}
 
-		$needle = '#(https?:)?//instagr(\.am|am\.com)/p/([^/]+)#i';
+		$needle = '#(https?:)?//(www\.)?instagr(\.am|am\.com)/p/([^/]+)#i';
 		if ( preg_match( $needle, $attrs['url'], $matches ) ) {
-			$photo_id = $matches[3];
+			$photo_id = $matches[4];
 		} else {
 			return '';
 		}

--- a/tests/test-instagram-shortcode.php
+++ b/tests/test-instagram-shortcode.php
@@ -8,6 +8,12 @@ class Test_Instagram_Shortcode extends WP_UnitTestCase {
 		$this->assertContains( '<iframe class="shortcake-bakery-responsive" src="https://instagram.com/p/3QcZmWP5To/embed/" width="612" height="710" frameborder="0" scrolling="no"></iframe>', apply_filters( 'the_content', $post->post_content ) );
 	}
 
+	public function test_post_display_with_www() {
+		$post_id = $this->factory->post->create( array( 'post_content' => '[instagram url="https://www.instagram.com/p/3QcZmWP5To/"]' ) );
+		$post = get_post( $post_id );
+		$this->assertContains( '<iframe class="shortcake-bakery-responsive" src="https://instagram.com/p/3QcZmWP5To/embed/" width="612" height="710" frameborder="0" scrolling="no"></iframe>', apply_filters( 'the_content', $post->post_content ) );
+	}
+
 	public function test_embed_reversal() {
 		$old_content = <<<EOT
 		apples before
@@ -77,5 +83,4 @@ EOT;
 		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
 		$this->assertEquals( $expected_content, $transformed_content );
 	}
-
 }


### PR DESCRIPTION
This allows embeds from www.instagram.com to be rendered, rather than
only accepting the instagram.com domain.

#166