### PR TITLE
Tweak to shortcake bakery responsive class

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+indent_size = 4
 
 [readme.txt,*.md,*.markdown]
 trim_trailing_whitespace = false

--- a/assets/js/shortcake-bakery.js
+++ b/assets/js/shortcake-bakery.js
@@ -51,8 +51,8 @@
 				}
 			});
 			responsiveElements();
-			$(window).on( 'resize', debounce( responsiveElements, 100 ));
 		}
 	});
+	$(window).on( 'resize', debounce( responsiveElements, 100 ));	
 
 }( jQuery ) );


### PR DESCRIPTION
I am configuring Shortcake Bakery on a new site. I noticed that the `responsiveElements` function was not being triggered on resize. This pull request leaves the initial on ready call to `responsiveElements` as-is, but moves followup calls to their own on resize function. 