### PR TITLE
Add "script" type for ABC News shortcode

### DIFF
--- a/inc/shortcodes/class-abc-news.php
+++ b/inc/shortcodes/class-abc-news.php
@@ -12,6 +12,16 @@ class ABC_News extends Shortcode {
 			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-abc-news.svg' ) . '" />',
 			'attrs'          => array(
 				array(
+					'label'        => esc_html__( 'Type', 'shortcake-bakery' ),
+					'attr'         => 'type',
+					'type'         => 'select',
+					'options'      => array(
+						'iframe' => esc_html__( 'Iframe', 'shortcake-bakery' ),
+						'script' => esc_html__( 'Script tag', 'shortcake-bakery' ),
+					),
+					'description'  => esc_html__( 'URL to a ABC News video', 'shortcake-bakery' ),
+				),
+				array(
 					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
 					'attr'         => 'url',
 					'type'         => 'text',
@@ -29,7 +39,18 @@ class ABC_News extends Shortcode {
 				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 					continue;
 				}
-				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
+				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' type="iframe" url="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
+			}
+			$content = self::make_replacements_to_content( $content, $replacements );
+		}
+
+		if ( $scripts = self::parse_scripts( $content ) ) {
+			$replacements = array();
+			foreach ( $scripts as $script ) {
+				if ( ! in_array( self::parse_url( $script->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+					continue;
+				}
+				$replacements[ $script->original ] = '[' . self::get_shortcode_tag() . ' type="script" url="' . esc_url_raw( $script->attrs['src'] ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
 		}
@@ -38,12 +59,18 @@ class ABC_News extends Shortcode {
 	}
 
 	public static function callback( $attrs, $content = '' ) {
+		$attrs = wp_parse_args( $attrs, array( 'type' => 'iframe' ) );
 
 		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 			return '';
 		}
 
-		return sprintf( '<iframe class="shortcake-bakery-responsive" width="640" height="480" src="%s" frameborder="0"></iframe>', esc_url( $attrs['url'] ) );
+		switch ( $attrs['type'] ) {
+			case 'iframe':
+				return sprintf( '<iframe class="shortcake-bakery-responsive" width="640" height="480" src="%s" frameborder="0"></iframe>', esc_url( $attrs['url'] ) );
+			case 'script':
+				return sprintf( '<script src="%s"></script>', esc_url( $attrs['url'] ) );
+		}
 	}
 
 }

--- a/tests/test-abc-news-shortcode.php
+++ b/tests/test-abc-news-shortcode.php
@@ -2,13 +2,19 @@
 
 class Test_ABC_News_Shortcode extends WP_UnitTestCase {
 
-	public function test_post_display() {
+	public function test_post_display_with_iframe() {
 		$post_id = $this->factory->post->create( array( 'post_content' => '[abc-news url="http://abcnews.go.com/video/embed?id=33317297"]' ) );
 		$post = get_post( $post_id );
 		$this->assertContains( '<iframe class="shortcake-bakery-responsive" width="640" height="480" src="http://abcnews.go.com/video/embed?id=33317297" frameborder="0"></iframe>', apply_filters( 'the_content', $post->post_content ) );
 	}
 
-	public function test_embed_reversal() {
+	public function test_post_display_with_script() {
+		$post_id = $this->factory->post->create( array( 'post_content' => '[abc-news type="script" url="http://abcnews.go.com/javascript/portableplayer?id=14476486&autoStart=true&size=inpage&affil=true"]' ) );
+		$post = get_post( $post_id );
+		$this->assertContains( '<script src="http://abcnews.go.com/javascript/portableplayer?id=14476486&#038;autoStart=true&#038;size=inpage&#038;affil=true"></script>', apply_filters( 'the_content', $post->post_content ) );
+	}
+
+	public function test_iframe_embed_reversal() {
 		$old_content = <<<EOT
 		apples before
 
@@ -20,7 +26,7 @@ EOT;
 		$expected_content = <<<EOT
 		apples before
 
-		[abc-news url="http://abcnews.go.com/video/embed?id=33317297"]
+		[abc-news type="iframe" url="http://abcnews.go.com/video/embed?id=33317297"]
 
 		bananas after
 EOT;
@@ -30,4 +36,25 @@ EOT;
 		$this->assertEquals( $expected_content, $transformed_content );
 	}
 
+	public function test_script_embed_reversal() {
+		$old_content = <<<EOT
+		apples before
+
+		<script src="http://abcnews.go.com/javascript/portableplayer?id=14476486&autoStart=true&size=inpage&affil=true"></script>
+
+		bananas after
+EOT;
+
+		$expected_content = <<<EOT
+		apples before
+
+		[abc-news type="script" url="http://abcnews.go.com/javascript/portableplayer?id=14476486&amp;autoStart=true&amp;size=inpage&amp;affil=true"]
+
+		bananas after
+EOT;
+
+		$transformed_content = wp_filter_post_kses( $old_content );
+		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
+		$this->assertEquals( $expected_content, $transformed_content );
+	}
 }


### PR DESCRIPTION
Adds a "type" parameter to ABC News shortcode. If not set, defaults to "iframe", which was the previous representation. If set to "script", will just output a script tag, as used by ABC's embed javascript player.

#169