### PR TITLE
Cut Travis' workload in half

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ notifications:
   on_success: never
   on_failure: change
 
+branches:
+  only:
+    - master
+
 php:
   - 5.3
   - 5.5


### PR DESCRIPTION
Prevent duplicate builds from running on pull requests by only
triggering branch builds on master