### PR TITLE
Restrict enqueueing scripts to shortcode_ui_loaded_editor action

### DIFF
--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -53,7 +53,7 @@ class Shortcake_Bakery {
 		add_action( 'shortcode_ui_after_do_shortcode', function( $shortcode ) {
 			return Shortcake_Bakery::get_shortcake_admin_dependencies();
 		});
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
+		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_admin_enqueue_scripts' ) );
 		add_action( 'media_buttons', array( $this, 'action_media_buttons' ) );
 		add_action( 'wp_ajax_shortcake_bakery_embed_reverse', array( $this, 'action_ajax_shortcake_bakery_embed_reverse' ) );
 	}


### PR DESCRIPTION
The bakery scripts are getting enqueued on every admin page. The enqueue is failing since the `shortcode-ui` script is not registered/enqueued except when the editor is added to a page. Query Monitor reports this as a broken dependency.