### PR TITLE
Don't use `continue` when we mean `return`

### DIFF
--- a/inc/shortcodes/class-googledocs.php
+++ b/inc/shortcodes/class-googledocs.php
@@ -233,7 +233,7 @@ class GoogleDocs extends Shortcode {
 	 */
 	private static function parse_from_url( $url ) {
 		if ( ! in_array( self::parse_url( $url, PHP_URL_HOST ), self::$valid_hosts ) ) {
-			continue;
+			return;
 		}
 
 		$url_parts_regex = '#(?P<subdomain>docs|www)\.google\.com/' // The subdomain. Not used


### PR DESCRIPTION
~ you say goodbye, I say hello
~ you say stop, and I say go

Fixes what what previously didn't even throw a warning, but is a fatal in PHP7.

See #178