### PR TITLE
Fix PHPCS issues, errors in build

### DIFF
--- a/inc/shortcodes/class-abc-news.php
+++ b/inc/shortcodes/class-abc-news.php
@@ -26,7 +26,7 @@ class ABC_News extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 					continue;
 				}
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
@@ -39,7 +39,7 @@ class ABC_News extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-flickr.php
+++ b/inc/shortcodes/class-flickr.php
@@ -26,7 +26,7 @@ class Flickr extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 					continue;
 				}
 				$url = preg_replace( '#/player/?$#', '/', $iframe->attrs['src'] );
@@ -40,7 +40,7 @@ class Flickr extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-googledocs.php
+++ b/inc/shortcodes/class-googledocs.php
@@ -68,7 +68,7 @@ class GoogleDocs extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 					continue;
 				}
 
@@ -147,7 +147,7 @@ class GoogleDocs extends Shortcode {
 
 		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
 		$type = self::get_document_type( $attrs['url'] );
-		if ( ! in_array( $host, self::$valid_hosts ) || ! $type ) {
+		if ( ! in_array( $host, self::$valid_hosts, true ) || ! $type ) {
 			return '';
 		}
 
@@ -232,7 +232,7 @@ class GoogleDocs extends Shortcode {
 	 * @return array Array with the following attributes: "doc_type", "embed_id", "view_name", "query_string"
 	 */
 	private static function parse_from_url( $url ) {
-		if ( ! in_array( self::parse_url( $url, PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( ! in_array( self::parse_url( $url, PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 			continue;
 		}
 

--- a/inc/shortcodes/class-guardian.php
+++ b/inc/shortcodes/class-guardian.php
@@ -24,7 +24,7 @@ class Guardian extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'embed.theguardian.com' ) ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'embed.theguardian.com' ), true ) ) {
 					continue;
 				}
 				$path = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
@@ -39,7 +39,7 @@ class Guardian extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), array( 'theguardian.com', 'www.theguardian.com' ) ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), array( 'theguardian.com', 'www.theguardian.com' ), true ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-iframe.php
+++ b/inc/shortcodes/class-iframe.php
@@ -61,7 +61,7 @@ class Iframe extends Shortcode {
 			$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), $whitelisted_iframe_domains ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), $whitelisted_iframe_domains, true ) ) {
 					continue;
 				}
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' src="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
@@ -86,7 +86,7 @@ class Iframe extends Shortcode {
 		$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
 
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
-		if ( ! in_array( $host, $whitelisted_iframe_domains ) ) {
+		if ( ! in_array( $host, $whitelisted_iframe_domains, true ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-livestream.php
+++ b/inc/shortcodes/class-livestream.php
@@ -26,7 +26,7 @@ class Livestream extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 					continue;
 				}
 				// URL looks like: http://new.livestream.com/accounts/9035483/events/3424523/videos/64460770/player?width=480&height=270&autoPlay=false&mute=false
@@ -42,7 +42,7 @@ class Livestream extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-pdf.php
+++ b/inc/shortcodes/class-pdf.php
@@ -26,7 +26,7 @@ class PDF extends Shortcode {
 		$url = esc_url_raw( $attrs['url'] );
 
 		$url_for_parse = ( 0 === strpos( $url, '//' ) ) ? 'http:' . $url :  $url;
-		$scheme = parse_url( $url_for_parse, PHP_URL_SCHEME );
+		$scheme = wp_parse_url( $url_for_parse, PHP_URL_SCHEME );
 
 		$ext = pathinfo( $url, PATHINFO_EXTENSION );
 		if ( 'pdf' !== strtolower( $ext ) ) {

--- a/inc/shortcodes/class-pdf.php
+++ b/inc/shortcodes/class-pdf.php
@@ -26,7 +26,7 @@ class PDF extends Shortcode {
 		$url = esc_url_raw( $attrs['url'] );
 
 		$url_for_parse = ( 0 === strpos( $url, '//' ) ) ? 'http:' . $url :  $url;
-		$scheme = wp_parse_url( $url_for_parse, PHP_URL_SCHEME );
+		$scheme = self::parse_url( $url_for_parse, PHP_URL_SCHEME );
 
 		$ext = pathinfo( $url, PATHINFO_EXTENSION );
 		if ( 'pdf' !== strtolower( $ext ) ) {

--- a/inc/shortcodes/class-scribd.php
+++ b/inc/shortcodes/class-scribd.php
@@ -24,7 +24,7 @@ class Scribd extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'www.scribd.com', 'scribd.com' ) ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'www.scribd.com', 'scribd.com' ), true ) ) {
 					continue;
 				}
 				// URL looks like: https://www.scribd.com/embeds/272220183/content?start_page=1&amp;view_mode=scroll&amp;show_recommendations=true

--- a/inc/shortcodes/class-script.php
+++ b/inc/shortcodes/class-script.php
@@ -39,7 +39,7 @@ class Script extends Shortcode {
 			$shortcode_tag = static::get_shortcode_tag();
 			foreach ( $scripts as $script ) {
 				$host = self::parse_url( $script->attrs['src'], PHP_URL_HOST );
-				if ( ! in_array( $host, $whitelisted_script_domains ) ) {
+				if ( ! in_array( $host, $whitelisted_script_domains, true ) ) {
 					continue;
 				}
 				$replacements[ $script->original ] = '[' . $shortcode_tag . ' src="' . esc_url_raw( $script->attrs['src'] ) . '"]';
@@ -57,7 +57,7 @@ class Script extends Shortcode {
 
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
 
-		if ( ! in_array( $host, static::get_whitelisted_script_domains() ) ) {
+		if ( ! in_array( $host, static::get_whitelisted_script_domains(), true ) ) {
 			if ( current_user_can( 'edit_posts' ) ) {
 				return '<div class="shortcake-bakery-error"><p>' . sprintf( esc_html__( 'Invalid hostname in URL: %s', 'shortcake-bakery' ), esc_url( $attrs['src'] ) ) . '</p></div>';
 			} else {

--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -68,7 +68,9 @@ abstract class Shortcode {
 			$url = 'http:' . $url;
 			$added_protocol = true;
 		}
-		$ret = wp_parse_url( $url, $component );
+		// @codingStandardsIgnoreStart
+		$ret = parse_url( $url, $component );
+		// @codingStandardsIgnoreEnd
 		if ( $added_protocol && $ret ) {
 			if ( -1 === $component && isset( $ret['scheme'] ) ) {
 				unset( $ret['scheme'] );

--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -68,7 +68,7 @@ abstract class Shortcode {
 			$url = 'http:' . $url;
 			$added_protocol = true;
 		}
-		$ret = parse_url( $url, $component );
+		$ret = wp_parse_url( $url, $component );
 		if ( $added_protocol && $ret ) {
 			if ( -1 === $component && isset( $ret['scheme'] ) ) {
 				unset( $ret['scheme'] );

--- a/inc/shortcodes/class-soundcloud.php
+++ b/inc/shortcodes/class-soundcloud.php
@@ -64,8 +64,8 @@ class SoundCloud extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		$host = parse_url( $attrs['url'], PHP_URL_HOST );
-		if ( empty( $attrs['url'] ) || ! in_array( $host, array( 'soundcloud.com', 'api.soundcloud.com' ) ) ) {
+		$host = wp_parse_url( $attrs['url'], PHP_URL_HOST );
+		if ( empty( $attrs['url'] ) || ! in_array( $host, array( 'soundcloud.com', 'api.soundcloud.com' ), true ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-soundcloud.php
+++ b/inc/shortcodes/class-soundcloud.php
@@ -64,7 +64,7 @@ class SoundCloud extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		$host = wp_parse_url( $attrs['url'], PHP_URL_HOST );
+		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
 		if ( empty( $attrs['url'] ) || ! in_array( $host, array( 'soundcloud.com', 'api.soundcloud.com' ), true ) ) {
 			return '';
 		}

--- a/inc/shortcodes/class-videoo.php
+++ b/inc/shortcodes/class-videoo.php
@@ -27,7 +27,7 @@ class Videoo extends Shortcode {
 	 */
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || 'videoo.com' !== wp_parse_url( $attrs['url'], PHP_URL_HOST ) ) {
+		if ( empty( $attrs['url'] ) || 'videoo.com' !== self::parse_url( $attrs['url'], PHP_URL_HOST ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-videoo.php
+++ b/inc/shortcodes/class-videoo.php
@@ -27,7 +27,7 @@ class Videoo extends Shortcode {
 	 */
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || 'videoo.com' !== parse_url( $attrs['url'], PHP_URL_HOST ) ) {
+		if ( empty( $attrs['url'] ) || 'videoo.com' !== wp_parse_url( $attrs['url'], PHP_URL_HOST ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-vimeo.php
+++ b/inc/shortcodes/class-vimeo.php
@@ -50,7 +50,7 @@ class Vimeo extends Shortcode {
 		}
 
 		// Video ID is always the first part of the path
-		$path = wp_parse_url( $attrs['url'], PHP_URL_PATH );
+		$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
 		$parts = explode( '/', trim( $path, '/' ) );
 		$video_id = $parts[0];
 		$embed_url = 'https://player.vimeo.com/video/' . $video_id;

--- a/inc/shortcodes/class-vimeo.php
+++ b/inc/shortcodes/class-vimeo.php
@@ -45,12 +45,12 @@ class Vimeo extends Shortcode {
 
 		$valid_hosts = array( 'www.vimeo.com', 'vimeo.com' );
 		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
-		if ( empty( $attrs['url'] ) || ! in_array( $host, $valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( $host, $valid_hosts, true ) ) {
 			return '';
 		}
 
 		// Video ID is always the first part of the path
-		$path = parse_url( $attrs['url'], PHP_URL_PATH );
+		$path = wp_parse_url( $attrs['url'], PHP_URL_PATH );
 		$parts = explode( '/', trim( $path, '/' ) );
 		$video_id = $parts[0];
 		$embed_url = 'https://player.vimeo.com/video/' . $video_id;

--- a/inc/shortcodes/class-vine.php
+++ b/inc/shortcodes/class-vine.php
@@ -78,7 +78,7 @@ class Vine extends Shortcode {
 		}
 
 		// ID is always the second part to the path
-		$path = parse_url( $attrs['url'], PHP_URL_PATH );
+		$path = wp_parse_url( $attrs['url'], PHP_URL_PATH );
 		$parts = explode( '/', trim( $path, '/' ) );
 		$embed_id = $parts[1];
 		$embed_url = 'https://vine.co/v/' . $embed_id . '/embed/' . $type;

--- a/inc/shortcodes/class-vine.php
+++ b/inc/shortcodes/class-vine.php
@@ -78,7 +78,7 @@ class Vine extends Shortcode {
 		}
 
 		// ID is always the second part to the path
-		$path = wp_parse_url( $attrs['url'], PHP_URL_PATH );
+		$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
 		$parts = explode( '/', trim( $path, '/' ) );
 		$embed_id = $parts[1];
 		$embed_url = 'https://vine.co/v/' . $embed_id . '/embed/' . $type;

--- a/inc/shortcodes/class-youtube.php
+++ b/inc/shortcodes/class-youtube.php
@@ -26,7 +26,7 @@ class YouTube extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 					continue;
 				}
 				if ( preg_match( '#youtube\.com/embed/([^/?]+)#', $iframe->attrs['src'], $matches ) ) {
@@ -46,14 +46,14 @@ class YouTube extends Shortcode {
 	public static function callback( $attrs, $content = '' ) {
 
 		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
-		if ( empty( $attrs['url'] ) || ! in_array( $host, self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( $host, self::$valid_hosts, true ) ) {
 			return '';
 		}
 
 		$list_id = '';
 
 		// https://www.youtube.com/watch?v=hDlpVFDmXrc
-		if ( in_array( $host, self::$valid_hosts ) ) {
+		if ( in_array( $host, self::$valid_hosts, true ) ) {
 			$query = self::parse_url( str_replace( array( '&amp;', '&#038;' ), '&', $attrs['url'] ), PHP_URL_QUERY );
 			parse_str( $query, $args );
 			if ( empty( $args['v'] ) ) {


### PR DESCRIPTION
Fixes the plugin build by ensuring that it passes all new code-sniffs:

- Strict mode for `in_array()` comparisons.
- Use `Shortcode::parse_url()` instead of `parse_url()` for backcompat with PHP < 5.4

This also merges #179, because the error fixed there was causing errors in unit tests.