### PR TITLE
Adds a "Disable autoplay" option for Livestream post elements

### DIFF
--- a/inc/shortcodes/class-livestream.php
+++ b/inc/shortcodes/class-livestream.php
@@ -17,6 +17,12 @@ class Livestream extends Shortcode {
 					'type'         => 'text',
 					'description'  => esc_html__( 'Full URL to the Livestream', 'shortcake-bakery' ),
 				),
+				array(
+					'label'        => esc_html__( 'Disable autoplay?', 'shortcake-bakery' ),
+					'attr'         => 'disableautoplay',
+					'type'         => 'checkbox',
+					'description'  => esc_html__( 'Livestream embeds autoplay by default.', 'shortcake-bakery' ),
+				),
 			),
 		);
 	}
@@ -50,6 +56,11 @@ class Livestream extends Shortcode {
 		if ( false === stripos( substr( $attrs['url'], strlen( $attrs['url'] ) - 8 ), '/player' ) ) {
 			$attrs['url'] = rtrim( $attrs['url'], '/' ) . '/player/';
 		}
+
+		if ( ! empty( $attrs['disableautoplay'] ) ) {
+			$attrs['url'] = add_query_arg( 'autoPlay', 'false', $attrs['url'] );
+		}
+
 		return sprintf( '<iframe class="shortcake-bakery-responsive" width="560" height="315" src="%s" frameborder="0"></iframe>', esc_url( $attrs['url'] ) );
 	}
 

--- a/tests/test-livestream-shortcode.php
+++ b/tests/test-livestream-shortcode.php
@@ -8,6 +8,12 @@ class Test_Livestream_Shortcode extends WP_UnitTestCase {
 		$this->assertContains( '<iframe class="shortcake-bakery-responsive" width="560" height="315" src="http://new.livestream.com/accounts/9035483/events/3424523/videos/64460770/player/" frameborder="0"></iframe>', apply_filters( 'the_content', $post->post_content ) );
 	}
 
+	public function test_post_display_no_autoplay() {
+		$post_id = $this->factory->post->create( array( 'post_content' => '[livestream url="http://new.livestream.com/accounts/9035483/events/3424523/videos/64460770/" disableautoplay="true" ]' ) );
+		$post = get_post( $post_id );
+		$this->assertContains( '<iframe class="shortcake-bakery-responsive" width="560" height="315" src="http://new.livestream.com/accounts/9035483/events/3424523/videos/64460770/player/?autoPlay=false" frameborder="0"></iframe>', apply_filters( 'the_content', $post->post_content ) );
+	}
+
 	public function test_embed_reversal() {
 		$old_content = <<<EOT
 


### PR DESCRIPTION
Livestream embeds autoplay by default. There are times where you might not want that. This enables that option by adding a "Disable autoplay?" attribute.

Connected to #183