### PR TITLE
Add reversal support for Facebook's new iFrame-based embeds.

### DIFF
--- a/inc/shortcodes/class-facebook.php
+++ b/inc/shortcodes/class-facebook.php
@@ -84,7 +84,7 @@ class Facebook extends Shortcode {
 					continue;
 				}
 				$possible_url = str_replace( 'https://www.facebook.com/plugins/post.php?href=', '', $iframe->attrs['src'] );
-				if( false !== strpos( $possible_url, '&' ) ) {
+				if ( false !== strpos( $possible_url, '&' ) ) {
 					$possible_url = substr( $possible_url, 0, strpos( $possible_url, '&' ) );
 				}
 				$possible_url = urldecode( $possible_url );
@@ -97,7 +97,6 @@ class Facebook extends Shortcode {
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
 		}
-
 
 		return $content;
 	}

--- a/inc/shortcodes/class-facebook.php
+++ b/inc/shortcodes/class-facebook.php
@@ -32,6 +32,7 @@ class Facebook extends Shortcode {
 	 */
 	public static function action_wp_footer() {
 		?>
+		<div id="fb-root"></div>
 		<script>
 			(function($){
 				$('.shortcake-bakery-responsive.fb-post').on('shortcake-bakery-responsive-resize', function(){
@@ -141,8 +142,7 @@ class Facebook extends Shortcode {
 		if ( ! has_action( 'wp_footer', 'Shortcake_Bakery\Shortcodes\Facebook::action_wp_footer' ) ) {
 			add_action( 'wp_footer', 'Shortcake_Bakery\Shortcodes\Facebook::action_wp_footer' );
 		}
-		$out = '<div id="fb-root"></div>';
-		$out .= '<div class="fb-post shortcake-bakery-responsive" data-href="' . esc_url( $attrs['url'] ) . '" data-width="350px" data-true-height="550px" data-true-width="350px"><div class="fb-xfbml-parse-ignore"></div></div>';
+		$out = '<div class="fb-post shortcake-bakery-responsive" data-href="' . esc_url( $attrs['url'] ) . '" data-width="350px" data-true-height="550px" data-true-width="350px"><div class="fb-xfbml-parse-ignore"></div></div>';
 		return $out;
 	}
 

--- a/inc/shortcodes/class-facebook.php
+++ b/inc/shortcodes/class-facebook.php
@@ -52,29 +52,53 @@ class Facebook extends Shortcode {
 
 	public static function reversal( $content ) {
 
-		if ( false === stripos( $content, '<script' ) ) {
-			return $content;
+		/* Pattern for script-based Facebook embeds */
+		if ( false !== stripos( $content, '<script' ) ) {
+
+			if ( preg_match_all( '#<div id="fb-root"></div><script>[^<]+</script><div class="fb-post" [^>]+href=[\'\"]([^\'\"]+)[\'\"].+</div>(</div>)?#', $content, $matches ) ) {
+				$replacements = array();
+				$shortcode_tag = self::get_shortcode_tag();
+				foreach ( $matches[0] as $key => $value ) {
+					$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[1][ $key ] ) . '"]';
+				}
+				$content = self::make_replacements_to_content( $content, $replacements );
+			}
+
+			/* Pattern for Facebook video embeds */
+			if ( preg_match_all( '#<div id="fb-root"><\/div><script>[^<]+<\/script><div class="fb-video" [^>]+href=[\'\"][^\'\"]+[\'\"]><div class="fb-xfbml-parse-ignore"><blockquote cite=[\'\"][^\'\"]+[\'\"]><a href=[\'\"]([^\'\"]+)[\'\"]+.*?<\/div><\/div>?#', $content, $matches ) ) {
+				$replacements = array();
+				$shortcode_tag = self::get_shortcode_tag();
+				foreach ( $matches[0] as $key => $value ) {
+					$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( 'https://www.facebook.com' . $matches[1][ $key ] ) . '"]';
+				}
+				$content = self::make_replacements_to_content( $content, $replacements );
+			}
 		}
 
-		/* Pattern for normal Facebook embeds */
-		if ( preg_match_all( '#<div id="fb-root"></div><script>[^<]+</script><div class="fb-post" [^>]+href=[\'\"]([^\'\"]+)[\'\"].+</div>(</div>)?#', $content, $matches ) ) {
+		/* Pattern for iFrame Facebook embeds */
+		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
-			$shortcode_tag = self::get_shortcode_tag();
-			foreach ( $matches[0] as $key => $value ) {
-				$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[1][ $key ] ) . '"]';
+			$matches = array();
+			foreach ( $iframes as $iframe ) {
+				if ( 'www.facebook.com' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
+					continue;
+				}
+				$possible_url = str_replace( 'https://www.facebook.com/plugins/post.php?href=', '', $iframe->attrs['src'] );
+				if( false !== strpos( $possible_url, '&' ) ) {
+					$possible_url = substr( $possible_url, 0, strpos( $possible_url, '&' ) );
+				}
+				$possible_url = urldecode( $possible_url );
+				if ( 'www.facebook.com' === self::parse_url( $possible_url, PHP_URL_HOST ) ) {
+					$post_uri = $possible_url;
+				} else {
+					continue;
+				}
+				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $post_uri ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
 		}
 
-		/* Pattern for Facebook video embeds */
-		if ( preg_match_all( '#<div id="fb-root"><\/div><script>[^<]+<\/script><div class="fb-video" [^>]+href=[\'\"][^\'\"]+[\'\"]><div class="fb-xfbml-parse-ignore"><blockquote cite=[\'\"][^\'\"]+[\'\"]><a href=[\'\"]([^\'\"]+)[\'\"]+.*?<\/div><\/div>?#', $content, $matches ) ) {
-			$replacements = array();
-			$shortcode_tag = self::get_shortcode_tag();
-			foreach ( $matches[0] as $key => $value ) {
-				$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( 'https://www.facebook.com' . $matches[1][ $key ] ) . '"]';
-			}
-			$content = self::make_replacements_to_content( $content, $replacements );
-		}
+
 		return $content;
 	}
 

--- a/tests/test-facebook-shortcode.php
+++ b/tests/test-facebook-shortcode.php
@@ -99,4 +99,21 @@ EOT;
 
 	}
 
+	public function test_iframe_embed_reversal() {
+		$old_content = <<<EOT
+
+		apples before
+
+		<iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Ffusionmedianetwork%2Fposts%2F1513457675346872&width=500" width="500" height="508" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
+
+		bananas after
+EOT;
+		$transformed_content = wp_filter_post_kses( $old_content );
+		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
+		$this->assertContains( '[facebook url="https://www.facebook.com/fusionmedianetwork/posts/1513457675346872"]', $transformed_content );
+		$this->assertContains( 'apples before', $transformed_content );
+		$this->assertContains( 'bananas after', $transformed_content );
+
+	}
+
 }


### PR DESCRIPTION
Facebook has changed their embed post code to use iFrames, which won't get reversed by the `<script>` reversal detection. This adds support for the new format, while keeping support for the old.


Example of a new iFrame embed:
```
<iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Ffusionmedianetwork%2Fposts%2F1513457675346872&width=500" width="500" height="508" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
```