### PR TITLE
Add new allowed URL formats for Scribd post element

### DIFF
--- a/inc/shortcodes/class-scribd.php
+++ b/inc/shortcodes/class-scribd.php
@@ -43,7 +43,7 @@ class Scribd extends Shortcode {
 			return '';
 		}
 
-		if ( ! preg_match( '#(http|https)://www\.scribd\.com/doc/?(\d)+/#', $attrs['url'], $needle ) ) {
+		if ( ! preg_match( '#(http|https)://www\.scribd\.com/doc(ument)?/?(\d)+/#', $attrs['url'], $needle ) ) {
 			if ( current_user_can( 'edit_posts' ) ) {
 				return '<div class="shortcake-bakery-error"><p>' . sprintf( esc_html__( 'Invalid Scribd URL: %s', 'shortcake-bakery' ), esc_url( $attrs['url'] ) ) . '</p></div>';
 			} else {

--- a/tests/test-scribd-shortcode.php
+++ b/tests/test-scribd-shortcode.php
@@ -10,6 +10,14 @@ class Test_Scribd_Shortcode extends WP_UnitTestCase {
 		$this->assertContains( '<iframe class="scribd_iframe_embed shortcake-bakery-responsive" src="' . esc_url( $embed_url ) . '" data-auto-height="false" data-aspect-ratio="0.7631133671742809" scrolling="no" width="100%" height="600" frameborder="0"></iframe>', apply_filters( 'the_content', $post->post_content ) );
 	}
 
+	public function test_post_display_document_url() {
+		$doc_url = 'https://www.scribd.com/document/320812028/Kansas-Maxmind-Complaint';
+		$embed_url = 'https://www.scribd.com/embeds/320812028/content?start_page=1&view_mode=scroll&access_key=key-ooxdrkmSg8ieauz9qYXL&show_recommendations=true';
+		$post_id = $this->factory->post->create( array( 'post_content' => '[scribd url="' . $doc_url . '"]' ) );
+		$post = get_post( $post_id );
+		$this->assertContains( '<iframe class="scribd_iframe_embed shortcake-bakery-responsive" src="' . esc_url( $embed_url ) . '" data-auto-height="false" data-aspect-ratio="0.7631133671742809" scrolling="no" width="100%" height="600" frameborder="0"></iframe>', apply_filters( 'the_content', $post->post_content ) );
+	}
+
 	public function test_embed_reversal() {
 		$old_content = <<<EOT
 


### PR DESCRIPTION
Allows documents of the format https://www.scribd.com/document/320812028/Kansas-Maxmind-Complaint - the previous URL validation expected the slug `doc` only.