### PR TITLE
Allow plugins to filter iFrame and Script embed sources.

### DIFF
--- a/inc/shortcodes/class-iframe.php
+++ b/inc/shortcodes/class-iframe.php
@@ -50,17 +50,6 @@ class Iframe extends Shortcode {
 	}
 
 	/**
-	*
-	* Determine whether or not we're forcing SSL on iFrame embeds
-	* Force SSL on iFrames using `add_filter` on this hook to return true.
-	*
-	* @return bool
-	*/
-	public static function force_ssl_iframes() {
-		return apply_filters( 'shortcake_bakery_force_ssl_iframes', false );
-	}
-
-	/**
 	 * Transform any <iframe> embeds within content to our iframe shortcode
 	 *
 	 * @param string $content
@@ -94,16 +83,15 @@ class Iframe extends Shortcode {
 			'disableresponsiveness'   => false,
 			);
 		$attrs = array_merge( $defaults, $attrs );
+
+		// Allow iFrame URLs to be filtered
+		$attrs['src'] = apply_filters( 'shortcake_bakery_iframe_src', $attrs['src'], $attrs );
+
 		$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
 
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
 		if ( ! in_array( $host, $whitelisted_iframe_domains, true ) ) {
 			return '';
-		}
-
-		if ( static::force_ssl_iframes() ) {
-			// Force HTTPS embeds
-			$attrs['src'] = str_replace( 'http:', 'https:', $attrs['src'] );
 		}
 
 		if ( $attrs['disableresponsiveness'] ) {

--- a/inc/shortcodes/class-iframe.php
+++ b/inc/shortcodes/class-iframe.php
@@ -87,11 +87,13 @@ class Iframe extends Shortcode {
 		// Allow iFrame URLs to be filtered
 		$attrs['src'] = apply_filters( 'shortcake_bakery_iframe_src', $attrs['src'], $attrs );
 
-		$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
-
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
-		if ( ! in_array( $host, $whitelisted_iframe_domains, true ) ) {
-			return '';
+		if ( ! in_array( $host, static::get_whitelisted_iframe_domains(), true ) ) {
+			if ( current_user_can( 'edit_posts' ) ) {
+				return '<div class="shortcake-bakery-error"><p>' . sprintf( esc_html__( 'Invalid hostname in URL: %s', 'shortcake-bakery' ), esc_url( $attrs['src'] ) ) . '</p></div>';
+			} else {
+				return '';
+			}
 		}
 
 		if ( $attrs['disableresponsiveness'] ) {

--- a/inc/shortcodes/class-iframe.php
+++ b/inc/shortcodes/class-iframe.php
@@ -50,6 +50,17 @@ class Iframe extends Shortcode {
 	}
 
 	/**
+	*
+	* Determine whether or not we're forcing SSL on iFrame embeds
+	* Force SSL on iFrames using `add_filter` on this hook to return true.
+	*
+	* @return bool
+	*/
+	public static function force_ssl_iframes() {
+		return apply_filters( 'shortcake_bakery_force_ssl_iframes', false );
+	}
+
+	/**
 	 * Transform any <iframe> embeds within content to our iframe shortcode
 	 *
 	 * @param string $content
@@ -88,6 +99,11 @@ class Iframe extends Shortcode {
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
 		if ( ! in_array( $host, $whitelisted_iframe_domains, true ) ) {
 			return '';
+		}
+
+		if ( static::force_ssl_iframes() ) {
+			// Force HTTPS embeds
+			$attrs['src'] = str_replace( 'http:', 'https:', $attrs['src'] );
 		}
 
 		if ( $attrs['disableresponsiveness'] ) {

--- a/inc/shortcodes/class-script.php
+++ b/inc/shortcodes/class-script.php
@@ -31,17 +31,6 @@ class Script extends Shortcode {
 		return apply_filters( 'shortcake_bakery_whitelisted_script_domains', array() );
 	}
 
-	/**
-	*
-	* Determine whether or not we're forcing SSL on script embeds
-	* Force SSL on scripts using `add_filter` on this hook to return true.
-	*
-	* @return bool
-	*/
-	public static function force_ssl_scripts() {
-		return apply_filters( 'shortcake_bakery_force_ssl_scripts', false );
-	}
-
 	public static function reversal( $content ) {
 
 		if ( $scripts = self::parse_scripts( $content ) ) {
@@ -66,6 +55,9 @@ class Script extends Shortcode {
 			return '';
 		}
 
+		// Allow script URLs to be filtered
+		$attrs['src'] = apply_filters( 'shortcake_bakery_script_src', $attrs['src'], $attrs );
+
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
 
 		if ( ! in_array( $host, static::get_whitelisted_script_domains(), true ) ) {
@@ -74,11 +66,6 @@ class Script extends Shortcode {
 			} else {
 				return '';
 			}
-		}
-
-		if ( static::force_ssl_scripts() ) {
-			// Force HTTPS embeds
-			$attrs['src'] = str_replace( 'http:', 'https:', $attrs['src'] );
 		}
 
 		return '<script src="' . esc_url( $attrs['src'] ) . '"></script>';

--- a/inc/shortcodes/class-script.php
+++ b/inc/shortcodes/class-script.php
@@ -59,7 +59,6 @@ class Script extends Shortcode {
 		$attrs['src'] = apply_filters( 'shortcake_bakery_script_src', $attrs['src'], $attrs );
 
 		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
-
 		if ( ! in_array( $host, static::get_whitelisted_script_domains(), true ) ) {
 			if ( current_user_can( 'edit_posts' ) ) {
 				return '<div class="shortcake-bakery-error"><p>' . sprintf( esc_html__( 'Invalid hostname in URL: %s', 'shortcake-bakery' ), esc_url( $attrs['src'] ) ) . '</p></div>';

--- a/inc/shortcodes/class-script.php
+++ b/inc/shortcodes/class-script.php
@@ -31,6 +31,17 @@ class Script extends Shortcode {
 		return apply_filters( 'shortcake_bakery_whitelisted_script_domains', array() );
 	}
 
+	/**
+	*
+	* Determine whether or not we're forcing SSL on script embeds
+	* Force SSL on scripts using `add_filter` on this hook to return true.
+	*
+	* @return bool
+	*/
+	public static function force_ssl_scripts() {
+		return apply_filters( 'shortcake_bakery_force_ssl_scripts', false );
+	}
+
 	public static function reversal( $content ) {
 
 		if ( $scripts = self::parse_scripts( $content ) ) {
@@ -63,6 +74,11 @@ class Script extends Shortcode {
 			} else {
 				return '';
 			}
+		}
+
+		if ( static::force_ssl_scripts() ) {
+			// Force HTTPS embeds
+			$attrs['src'] = str_replace( 'http:', 'https:', $attrs['src'] );
 		}
 
 		return '<script src="' . esc_url( $attrs['src'] ) . '"></script>';

--- a/tests/test-iframe-shortcode.php
+++ b/tests/test-iframe-shortcode.php
@@ -65,6 +65,17 @@ EOT;
 		$this->assertEquals( $expected_content, $transformed_content );
 	}
 
+	public function test_force_ssl_embed() {
+		add_filter( 'shortcake_bakery_force_ssl_iframes', function(){
+			return true;
+		});
+		$post_id = $this->factory->post->create( array( 'post_content' => '[iframe src="http://static.fusion.net/the-ultimate-choice/"]' ) );
+		$post = get_post( $post_id );
+		$filtered_content = apply_filters( 'the_content', $post->post_content );
+		$this->assertNotContains( 'http://static.fusion.net/the-ultimate-choice/', $filtered_content );
+		$this->assertContains( 'https://static.fusion.net/the-ultimate-choice/', $filtered_content );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 		remove_filter( 'shortcake_bakery_whitelisted_iframe_domains', $this->filter_callback );

--- a/tests/test-script-shortcode.php
+++ b/tests/test-script-shortcode.php
@@ -77,4 +77,15 @@ EOT;
 		$this->assertEmpty( trim( apply_filters( 'the_content', $transformed_content ) ) );
 	}
 
+	public function test_force_ssl_embed() {
+		add_filter( 'shortcake_bakery_force_ssl_scripts', function(){
+			return true;
+		});
+		$post_id = $this->factory->post->create( array( 'post_content' => '[script src="http://3vot.com/fusion/waittimes/3vot.js"]' ) );
+		$post = get_post( $post_id );
+		$filtered_content = apply_filters( 'the_content', $post->post_content );
+		$this->assertNotContains( 'http://3vot.com/fusion/waittimes/3vot.js', $filtered_content );
+		$this->assertContains( 'https://3vot.com/fusion/waittimes/3vot.js', $filtered_content );
+	}
+
 }


### PR DESCRIPTION
This makes it easy to retroactively apply HTTPS schemes to existing embeds when prepping a site to serve correctly over HTTPS.