### PR TITLE
194 instagram responsive embeds

### DIFF
--- a/assets/js/shortcake-bakery.js
+++ b/assets/js/shortcake-bakery.js
@@ -30,9 +30,11 @@
 				parentWidth = parent.innerWidth;
 			}
 
+			var heightAdj = el.data('height-adjust') ? el.data('height-adjust') : 0;
+
 			var trueHeight = el.data('true-height') ? el.data('true-height') : 360;
 			var trueWidth = el.data('true-width') ? el.data('true-width') : 640;
-			var newHeight = ( parentWidth / trueWidth ) * trueHeight;
+			var newHeight = ( ( parentWidth / trueWidth ) * trueHeight ) + heightAdj;
 			$(this).css('height', newHeight + 'px' ).css('width', parentWidth + 'px');
 			$(this).trigger('shortcake-bakery-responsive-resize');
 		});

--- a/assets/js/shortcake-bakery.js
+++ b/assets/js/shortcake-bakery.js
@@ -30,11 +30,11 @@
 				parentWidth = parent.innerWidth;
 			}
 
-			var heightAdj = el.data('height-adjust') ? el.data('height-adjust') : 0;
+			var heightAdjust = el.data('height-adjust') ? el.data('height-adjust') : 0;
 
 			var trueHeight = el.data('true-height') ? el.data('true-height') : 360;
 			var trueWidth = el.data('true-width') ? el.data('true-width') : 640;
-			var newHeight = ( ( parentWidth / trueWidth ) * trueHeight ) + heightAdj;
+			var newHeight = ( ( parentWidth / trueWidth ) * trueHeight ) + heightAdjust;
 			$(this).css('height', newHeight + 'px' ).css('width', parentWidth + 'px');
 			$(this).trigger('shortcake-bakery-responsive-resize');
 		});
@@ -48,7 +48,9 @@
 				if ( el.attr('height') && el.attr('width')
 					&& ! el.data('true-width') && ! el.data('true-height')
 					&& -1 === el.attr('height').indexOf('%') && -1 === el.attr('width').indexOf('%') ) {
-					el.data('true-height', el.attr('height'));
+
+					var heightAdjust = el.data('height-adjust') ? el.data('height-adjust') : 0;
+					el.data('true-height', el.attr('height') - heightAdjust);
 					el.data('true-width', el.attr('width'));
 				}
 			});

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   ],
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.3.4",
+    "squizlabs/php_codesniffer": "^2.6",
     "wp-coding-standards/wpcs": "dev-master"
   },
   "scripts": {

--- a/inc/shortcodes/class-instagram.php
+++ b/inc/shortcodes/class-instagram.php
@@ -67,8 +67,13 @@ class Instagram extends Shortcode {
 			return '';
 		}
 
-		return sprintf( '<iframe class="shortcake-bakery-responsive" src="%s" width="612" height="710" frameborder="0" scrolling="no"></iframe>',
-			esc_url( sprintf( 'https://instagram.com/p/%s/embed/', $photo_id ) )
+		$image_ratio = ( ! empty( $attrs['ratio'] ) ) ? floatval( $attrs['ratio'] ) : 100.0;
+
+		$height = round( 612 * ( $image_ratio / 100 ) );
+
+		return sprintf( '<iframe data-height-adjust="96" class="shortcake-bakery-responsive" src="%s" width="612" height="%s" frameborder="0" scrolling="no"></iframe>',
+			esc_url( sprintf( 'https://instagram.com/p/%s/embed/', $photo_id ) ),
+			esc_attr( $height )
 		);
 	}
 

--- a/tests/test-instagram-shortcode.php
+++ b/tests/test-instagram-shortcode.php
@@ -103,4 +103,27 @@ EOT;
 		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
 		$this->assertEquals( $expected_content, $transformed_content );
 	}
+
+	public function test_embed_reversal_with_non_standard_ratio() {
+		$old_content = <<<EOT
+		apples before
+
+<blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:33.2407407407% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/BJcSHUTgAI0/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A photo posted by 渡辺直美 (@watanabenaomi703)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-08-23T06:55:49+00:00">Aug 22, 2016 at 11:55pm PDT</time></p></div></blockquote>
+<script async defer src="//platform.instagram.com/en_US/embeds.js"></script>
+
+		bananas after
+EOT;
+
+		$expected_content = <<<EOT
+		apples before
+
+		[instagram url="https://www.instagram.com/p/BJcSHUTgAI0/" ratio="66.4815"]
+
+		bananas after
+EOT;
+
+		$transformed_content = wp_filter_post_kses( $old_content );
+		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
+		$this->assertEquals( $expected_content, $transformed_content );
+	}
 }

--- a/tests/test-instagram-shortcode.php
+++ b/tests/test-instagram-shortcode.php
@@ -5,13 +5,13 @@ class Test_Instagram_Shortcode extends WP_UnitTestCase {
 	public function test_post_display() {
 		$post_id = $this->factory->post->create( array( 'post_content' => '[instagram url="https://instagram.com/p/3QcZmWP5To/"]' ) );
 		$post = get_post( $post_id );
-		$this->assertContains( '<iframe class="shortcake-bakery-responsive" src="https://instagram.com/p/3QcZmWP5To/embed/" width="612" height="710" frameborder="0" scrolling="no"></iframe>', apply_filters( 'the_content', $post->post_content ) );
+		$this->assertContains( '<iframe data-height-adjust="96" class="shortcake-bakery-responsive" src="https://instagram.com/p/3QcZmWP5To/embed/" width="612" height="708" frameborder="0" scrolling="no"></iframe>', apply_filters( 'the_content', $post->post_content ) );
 	}
 
 	public function test_post_display_with_www() {
 		$post_id = $this->factory->post->create( array( 'post_content' => '[instagram url="https://www.instagram.com/p/3QcZmWP5To/"]' ) );
 		$post = get_post( $post_id );
-		$this->assertContains( '<iframe class="shortcake-bakery-responsive" src="https://instagram.com/p/3QcZmWP5To/embed/" width="612" height="710" frameborder="0" scrolling="no"></iframe>', apply_filters( 'the_content', $post->post_content ) );
+		$this->assertContains( '<iframe data-height-adjust="96" class="shortcake-bakery-responsive" src="https://instagram.com/p/3QcZmWP5To/embed/" width="612" height="708" frameborder="0" scrolling="no"></iframe>', apply_filters( 'the_content', $post->post_content ) );
 	}
 
 	public function test_embed_reversal_v4() {
@@ -50,7 +50,7 @@ EOT;
 		$expected_content = <<<EOT
 		apples before
 
-		[instagram url="https://www.instagram.com/p/_r_r_FkHxE/"]
+		[instagram url="https://www.instagram.com/p/_r_r_FkHxE/" ratio="75.2591"]
 
 		bananas after
 EOT;
@@ -108,7 +108,7 @@ EOT;
 		$old_content = <<<EOT
 		apples before
 
-<blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:33.2407407407% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/BJcSHUTgAI0/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A photo posted by 渡辺直美 (@watanabenaomi703)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-08-23T06:55:49+00:00">Aug 22, 2016 at 11:55pm PDT</time></p></div></blockquote>
+		<blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:33.2407407407% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/BJcSHUTgAI0/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A photo posted by 渡辺直美 (@watanabenaomi703)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-08-23T06:55:49+00:00">Aug 22, 2016 at 11:55pm PDT</time></p></div></blockquote>
 <script async defer src="//platform.instagram.com/en_US/embeds.js"></script>
 
 		bananas after


### PR DESCRIPTION
Fixes the responsivity calculations for Instagram embeds to enable supporting non-square Instagram posts. Introduces a new setting which can be controlled by data attributes on other responsive iframe embeds, `data-height-adjust`. If this value is set on an embed, that portion of the height will be considered static, and the remainder of the height will scale linearly with the width.

(This fix also fixes #162, because it checks for the image height when reversing the embed code.)