### PR TITLE
Set WP_PLUGIN_DIR constant for tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,11 +5,14 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+define( 'WP_PLUGIN_DIR', dirname( dirname( dirname( __FILE__ ) ) ) );
+
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../shortcake-bakery.php';
 	require dirname( __FILE__ ) . '/class-shortcode.php';
+
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 


### PR DESCRIPTION
Prevents ugly failures caused by the symlink in the test suite.

Since the test suite failures in #197 are caused by the symlink in the test setup and not anything in the plugin itself, defining the plugin dir correctly for tests seems like the best solution here. (If a user wants to register symlinks for their individual setup, they'll have to do something like this anyways, either by defining the whole plugin directory in a constant as this is doing, or by adding a filter to `plugins_url` or `plugin_basename`.)