### PR TITLE
Fix codeblock syntax in README for plugin directory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Shortcake Bakery #
-**Contributors:** fusionengineering, davisshaver, danielbachhuber  
+**Contributors:** [fusionengineering](https://profiles.wordpress.org/fusionengineering), [davisshaver](https://profiles.wordpress.org/davisshaver), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber)  
 **Tags:** shortcodes, Facebook, Infogram, Playbuzz, Rap Genius, Scribd  
 **Requires at least:** 4.2  
 **Tested up to:** 4.3  
@@ -33,21 +33,21 @@ It's a plugin! Install it like any other.
 
 Most of the shortcodes work out of the box, but you'll need to whitelist any domains you want to be eligible for script and iFrame tag use.
 
-```php
+
 	add_filter( 'shortcake_bakery_whitelisted_script_domains', function(){
 		return array(
-			'ajax.googleapis.com',		
+			'ajax.googleapis.com',
 		);
 	});
-```
 
-```php
+
+
 	add_filter( 'shortcake_bakery_whitelisted_iframe_domains', function(){
 		return array(
-			'buzzfeed.com',		
+			'buzzfeed.com',
 		);
 	});
-```
+
 
 ## Screenshots ##
 

--- a/readme.txt
+++ b/readme.txt
@@ -33,21 +33,21 @@ It's a plugin! Install it like any other.
 
 Most of the shortcodes work out of the box, but you'll need to whitelist any domains you want to be eligible for script and iFrame tag use.
 
-```php
-	add_filter( 'shortcake_bakery_whitelisted_script_domains', function(){
-		return array(
-			'ajax.googleapis.com',		
-		);
-	});
-```
+`
+add_filter( 'shortcake_bakery_whitelisted_script_domains', function(){
+	return array(
+		'ajax.googleapis.com',
+	);
+});
+`
 
-```php
-	add_filter( 'shortcake_bakery_whitelisted_iframe_domains', function(){
-		return array(
-			'buzzfeed.com',		
-		);
-	});
-```
+`
+add_filter( 'shortcake_bakery_whitelisted_iframe_domains', function(){
+	return array(
+		'buzzfeed.com',
+	);
+});
+`
 
 == Screenshots ==
 


### PR DESCRIPTION
Triple-backticks don't mark a codeblock in the .org plugin directory. Fixing that here with the correct syntax (a single backtick on a line by itself before and after the code block in the readme.txt file, which gets converted to a tabbed section block in the README.md file.