### PR TITLE
Add support for YouTube short urls (youtu.be/xxxxxxxxxx)

### DIFF
--- a/inc/shortcodes/class-youtube.php
+++ b/inc/shortcodes/class-youtube.php
@@ -52,12 +52,10 @@ class YouTube extends Shortcode {
 
 		$list_id = '';
 
-		// Short url format: https://youtu.be/nc7F_qv3eI8
-		if ( 'youtu.be' === $host ) {
-			$embed_id = trim( self::parse_url( $attrs['url'], PHP_URL_PATH ) , '/' );
+		if ( 'youtu.be' === $host ) { // Short url format: https://youtu.be/nc7F_qv3eI8
+			$embed_id = trim( self::parse_url( $attrs['url'], PHP_URL_PATH ), '/' );
 
-		// https://www.youtube.com/watch?v=hDlpVFDmXrc
-		} else if ( in_array( $host, self::$valid_hosts, true ) ) {
+		} elseif ( in_array( $host, self::$valid_hosts, true ) ) { // https://www.youtube.com/watch?v=hDlpVFDmXrc
 			$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
 
 			$query = self::parse_url( str_replace( array( '&amp;', '&#038;' ), '&', $attrs['url'] ), PHP_URL_QUERY );

--- a/inc/shortcodes/class-youtube.php
+++ b/inc/shortcodes/class-youtube.php
@@ -4,7 +4,7 @@ namespace Shortcake_Bakery\Shortcodes;
 
 class YouTube extends Shortcode {
 
-	private static $valid_hosts = array( 'www.youtube.com', 'youtube.com' );
+	private static $valid_hosts = array( 'www.youtube.com', 'youtube.com', 'youtu.be' );
 
 	public static function get_shortcode_ui_args() {
 		return array(
@@ -52,8 +52,14 @@ class YouTube extends Shortcode {
 
 		$list_id = '';
 
+		// Short url format: https://youtu.be/nc7F_qv3eI8
+		if ( 'youtu.be' === $host ) {
+			$embed_id = trim( self::parse_url( $attrs['url'], PHP_URL_PATH ) , '/' );
+
 		// https://www.youtube.com/watch?v=hDlpVFDmXrc
-		if ( in_array( $host, self::$valid_hosts, true ) ) {
+		} else if ( in_array( $host, self::$valid_hosts, true ) ) {
+			$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
+
 			$query = self::parse_url( str_replace( array( '&amp;', '&#038;' ), '&', $attrs['url'] ), PHP_URL_QUERY );
 			parse_str( $query, $args );
 			if ( empty( $args['v'] ) ) {

--- a/tests/test-youtube-shortcode.php
+++ b/tests/test-youtube-shortcode.php
@@ -34,6 +34,12 @@ class Test_YouTube_Shortcode extends WP_UnitTestCase {
 		remove_filter( 'shortcake_bakery_youtube_embed_url', $filter );
 	}
 
+	public function test_youtube_short_url_display() {
+		$post_id = $this->factory->post->create( array( 'post_content' => '[youtube url="https://youtu.be/KzjHbbXH2XE"]' ) );
+		$post = get_post( $post_id );
+		$this->assertContains( '<iframe class="shortcake-bakery-responsive" width="640" height="360" src="https://youtube.com/embed/KzjHbbXH2XE" frameborder="0"></iframe>', apply_filters( 'the_content', $post->post_content ) );
+	}
+
 	public function test_embed_reversal() {
 		$old_content = <<<EOT
 		apples before


### PR DESCRIPTION
When trying to get a URL for a YouTube video, a logical place to look is
the "Share" link. The link provided if you click "Share", and then "Copy
URL", is a shortlink of the form `https://youtu.be/{embed_id}`.

This PR adds support for that url pattern to the Youtube post element.