### PR TITLE
Try to fix build by allowing latest version of PHPCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,10 @@ branches:
     - master
 
 php:
-  - 5.3
-  - 5.5
+  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-
-matrix:
-  include:
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
 
 cache:
   - composer

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
   ],
   "type": "wordpress-plugin",
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.8.1",
     "wp-coding-standards/wpcs": "dev-master"
   },
   "scripts": {

--- a/inc/class-asset-proxy.php
+++ b/inc/class-asset-proxy.php
@@ -25,7 +25,7 @@ class Asset_Proxy {
 	}
 
 	public function handle_asset_proxy() {
-		$asset_url = stripslashes( $_REQUEST['url'] );
+		$asset_url      = stripslashes( $_REQUEST['url'] );
 		$security_check = $_REQUEST['_nonce'];
 
 		if ( empty( $asset_url ) || ! wp_verify_nonce( $security_check, 'asset-proxy-' . $asset_url ) ) {
@@ -40,7 +40,8 @@ class Asset_Proxy {
 		 *
 		 * @param array HTTP options for asset stream
 		 */
-		$stream_options = apply_filters( 'shortcake_bakery_asset_proxy_stream_options',
+		$stream_options = apply_filters(
+			'shortcake_bakery_asset_proxy_stream_options',
 			array(
 				'http' => array(
 					'method'  => 'GET',

--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -9,7 +9,7 @@ class Shortcake_Bakery {
 
 	private $shortcake_bakery_embeds = true;
 
-	private $internal_shortcode_classes = array(
+	private $internal_shortcode_classes   = array(
 		'Shortcake_Bakery\Shortcodes\ABC_News',
 		'Shortcake_Bakery\Shortcodes\Facebook',
 		'Shortcake_Bakery\Shortcodes\Flickr',
@@ -34,9 +34,9 @@ class Shortcake_Bakery {
 		'Shortcake_Bakery\Shortcodes\Vimeo',
 		'Shortcake_Bakery\Shortcodes\Vine',
 		'Shortcake_Bakery\Shortcodes\YouTube',
-		);
+	);
 	private $registered_shortcode_classes = array();
-	private $registered_shortcodes = array();
+	private $registered_shortcodes        = array();
 
 	public static function get_instance() {
 
@@ -53,9 +53,11 @@ class Shortcake_Bakery {
 	 */
 	private function setup_actions() {
 		add_action( 'init', array( $this, 'action_init_register_shortcodes' ) );
-		add_action( 'shortcode_ui_after_do_shortcode', function( $shortcode ) {
-			return Shortcake_Bakery::get_shortcake_admin_dependencies();
-		});
+		add_action(
+			'shortcode_ui_after_do_shortcode', function( $shortcode ) {
+				return Shortcake_Bakery::get_shortcake_admin_dependencies();
+			}
+		);
 		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_admin_enqueue_scripts' ) );
 		add_action( 'media_buttons', array( $this, 'action_media_buttons' ) );
 		add_action( 'wp_ajax_shortcake_bakery_embed_reverse', array( $this, 'action_ajax_shortcake_bakery_embed_reverse' ) );
@@ -84,7 +86,7 @@ class Shortcake_Bakery {
 
 		$this->registered_shortcode_classes = apply_filters( 'shortcake_bakery_shortcode_classes', $this->internal_shortcode_classes );
 		foreach ( $this->registered_shortcode_classes as $class ) {
-			$shortcode_tag = $class::get_shortcode_tag();
+			$shortcode_tag                                 = $class::get_shortcode_tag();
 			$this->registered_shortcodes[ $shortcode_tag ] = $class;
 			add_shortcode( $shortcode_tag, array( $this, 'do_shortcode_callback' ) );
 			$class::setup_actions();
@@ -118,7 +120,7 @@ class Shortcake_Bakery {
 
 		wp_enqueue_script( 'shortcake-bakery', SHORTCAKE_BAKERY_URL_ROOT . 'assets/js/shortcake-bakery.js', array( 'jquery' ), SHORTCAKE_BAKERY_VERSION );
 
-		$class = $this->registered_shortcodes[ $shortcode_tag ];
+		$class  = $this->registered_shortcodes[ $shortcode_tag ];
 		$output = $class::callback( $attrs, $content, $shortcode_tag );
 		return apply_filters( 'shortcake_bakery_shortcode_callback', $output, $shortcode_tag, $attrs, $content );
 	}
@@ -133,7 +135,7 @@ class Shortcake_Bakery {
 		if ( ! is_admin() ) {
 			return;
 		}
-		$r = '<script src="' . esc_url( includes_url( 'js/jquery/jquery.js' ) ) . '"></script>';
+		$r  = '<script src="' . esc_url( includes_url( 'js/jquery/jquery.js' ) ) . '"></script>';
 		$r .= '<script type="text/javascript" src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/js/shortcake-bakery.js' ) . '"></script>';
 		return $r;
 	}
@@ -148,13 +150,13 @@ class Shortcake_Bakery {
 		if ( apply_filters( 'shortcake_bakery_show_add_embed', $this->shortcake_bakery_embeds ) ) {
 			wp_enqueue_script( 'shortcake-bakery-add-embed-media-frame', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/js/build/shortcake-bakery-add-embed-media-frame.js', array( 'media-views', 'shortcode-ui' ) );
 			$strings = array(
-				'text' => array(
-					'addEmbed'           => __( 'Insert Embed Code', 'shortcake-bakery' ),
-					'insertButton'       => __( 'Insert embed', 'shortcake-bakery' ),
-					'customEmbedLabel'   => __( 'Paste any custom embed code here. If it matches a known post element, that post element will be used rather than the embed code.', 'shortcake-bakery' ),
-					'noReversalMatches'  => __( 'The embed code provided doesn\'t match any known post elements. This means that it may not display as expected.', 'shortcake-bakery' ),
+				'text'       => array(
+					'addEmbed'          => __( 'Insert Embed Code', 'shortcake-bakery' ),
+					'insertButton'      => __( 'Insert embed', 'shortcake-bakery' ),
+					'customEmbedLabel'  => __( 'Paste any custom embed code here. If it matches a known post element, that post element will be used rather than the embed code.', 'shortcake-bakery' ),
+					'noReversalMatches' => __( 'The embed code provided doesn\'t match any known post elements. This means that it may not display as expected.', 'shortcake-bakery' ),
 				),
-				'nonces' => array(
+				'nonces'     => array(
 					'customEmbedReverse' => wp_create_nonce( 'embed-reverse' ),
 				),
 				'shortcodes' => array_flip( $this->registered_shortcodes ),
@@ -177,7 +179,8 @@ class Shortcake_Bakery {
 			return false;
 		}
 
-		printf( '<button type="button" class="button insert-embed shortcake-bakery-insert-embed" data-editor="%s"><span class="dashicons dashicons-editor-code"></span> %s</button>',
+		printf(
+			'<button type="button" class="button insert-embed shortcake-bakery-insert-embed" data-editor="%s"><span class="dashicons dashicons-editor-code"></span> %s</button>',
 			esc_attr( $editor_id ),
 			esc_html__( 'Add Embed', 'shortcake-bakery' )
 		);
@@ -188,9 +191,9 @@ class Shortcake_Bakery {
 			exit;
 		}
 		check_ajax_referer( 'embed-reverse', '_wpnonce' );
-		$post_id = intval( $_POST['post_id'] );
+		$post_id             = intval( $_POST['post_id'] );
 		$provided_embed_code = wp_unslash( $_POST['custom_embed_code'] );
-		$result = $this->reverse_embed( $provided_embed_code );
+		$result              = $this->reverse_embed( $provided_embed_code );
 
 		/**
 		 * Hook to transform the embed reversal response before returning it to the editor.
@@ -226,24 +229,24 @@ class Shortcake_Bakery {
 	 * }
 	 */
 	public function reverse_embed( $provided_embed_code ) {
-		$success = false;
+		$success    = false;
 		$shortcodes = array();
-		$reversal = apply_filters( 'pre_kses', $provided_embed_code );
+		$reversal   = apply_filters( 'pre_kses', $provided_embed_code );
 		if ( $reversal !== $provided_embed_code && preg_match_all( '/' . get_shortcode_regex() . '/s', $reversal, $matched_shortcodes, PREG_SET_ORDER ) ) {
 			$success = true;
 
 			foreach ( $matched_shortcodes as $matched_shortcode ) {
 				$shortcodes[] = array(
-					'shortcode' => $matched_shortcode[2],
-					'attributes' => shortcode_parse_atts( $matched_shortcode[3] ),
+					'shortcode'     => $matched_shortcode[2],
+					'attributes'    => shortcode_parse_atts( $matched_shortcode[3] ),
 					'inner_content' => $matched_shortcode[5],
-					'raw' => $matched_shortcode[0],
+					'raw'           => $matched_shortcode[0],
 				);
 			}
 		}
 		return array(
-			'success' => $success,
-			'reversal' => $reversal,
+			'success'    => $success,
+			'reversal'   => $reversal,
 			'shortcodes' => $shortcodes,
 		);
 	}

--- a/inc/shortcodes/class-abc-news.php
+++ b/inc/shortcodes/class-abc-news.php
@@ -8,14 +8,14 @@ class ABC_News extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'ABC News', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-abc-news.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'ABC News', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-abc-news.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to a ABC News video', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to a ABC News video', 'shortcake-bakery' ),
 				),
 			),
 		);

--- a/inc/shortcodes/class-facebook.php
+++ b/inc/shortcodes/class-facebook.php
@@ -6,25 +6,27 @@ class Facebook extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Facebook', 'shortcake-bakery' ),
-			'listItemImage'  => 'dashicons-facebook',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Facebook', 'shortcake-bakery' ),
+			'listItemImage' => 'dashicons-facebook',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the Facebook Post or Video', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the Facebook Post or Video', 'shortcake-bakery' ),
 				),
 			),
 		);
 	}
 
 	public static function setup_actions() {
-		add_action( 'shortcode_ui_after_do_shortcode', function( $shortcode ) {
-			if ( false !== stripos( $shortcode, '[' . self::get_shortcode_tag() ) ) {
+		add_action(
+			'shortcode_ui_after_do_shortcode', function( $shortcode ) {
+				if ( false !== stripos( $shortcode, '[' . self::get_shortcode_tag() ) ) {
 					echo '<script src="' . esc_url( '//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.0' ) . '"></script>';
+				}
 			}
-		});
+		);
 	}
 
 	/**
@@ -57,7 +59,7 @@ class Facebook extends Shortcode {
 		if ( false !== stripos( $content, '<script' ) ) {
 
 			if ( preg_match_all( '#<div id="fb-root"></div><script>[^<]+</script><div class="fb-post" [^>]+href=[\'\"]([^\'\"]+)[\'\"].+</div>(</div>)?#', $content, $matches ) ) {
-				$replacements = array();
+				$replacements  = array();
 				$shortcode_tag = self::get_shortcode_tag();
 				foreach ( $matches[0] as $key => $value ) {
 					$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[1][ $key ] ) . '"]';
@@ -67,7 +69,7 @@ class Facebook extends Shortcode {
 
 			/* Pattern for Facebook video embeds */
 			if ( preg_match_all( '#<div id="fb-root"><\/div><script>[^<]+<\/script><div class="fb-video" [^>]+href=[\'\"][^\'\"]+[\'\"]><div class="fb-xfbml-parse-ignore"><blockquote cite=[\'\"][^\'\"]+[\'\"]><a href=[\'\"]([^\'\"]+)[\'\"]+.*?<\/div><\/div>?#', $content, $matches ) ) {
-				$replacements = array();
+				$replacements  = array();
 				$shortcode_tag = self::get_shortcode_tag();
 				foreach ( $matches[0] as $key => $value ) {
 					$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( 'https://www.facebook.com' . $matches[1][ $key ] ) . '"]';
@@ -80,7 +82,7 @@ class Facebook extends Shortcode {
 		$iframes = self::parse_iframes( $content );
 		if ( $iframes ) {
 			$replacements = array();
-			$matches = array();
+			$matches      = array();
 			foreach ( $iframes as $iframe ) {
 				if ( 'www.facebook.com' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
@@ -122,7 +124,7 @@ class Facebook extends Shortcode {
 			'#https?:\/\/www?\.facebook\.com\/.*?\/photos\/([^/]+)/([\d])+/#',
 			'#https?:\/\/www?\.facebook\.com\/.*?\/videos\/([^/]+)/([\d])+/#',
 			'#https?:\/\/www?\.facebook\.com\/groups\/([\d])+\/permalink/([\d])+/?#',
-			);
+		);
 
 		$match = false;
 		foreach ( $facebook_regex as $regex ) {

--- a/inc/shortcodes/class-flickr.php
+++ b/inc/shortcodes/class-flickr.php
@@ -8,14 +8,14 @@ class Flickr extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Flickr', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-flickr.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Flickr', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-flickr.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to a Flickr gallery', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to a Flickr gallery', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -29,7 +29,7 @@ class Flickr extends Shortcode {
 				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts, true ) ) {
 					continue;
 				}
-				$url = preg_replace( '#/player/?$#', '/', $iframe->attrs['src'] );
+				$url                               = preg_replace( '#/player/?$#', '/', $iframe->attrs['src'] );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );

--- a/inc/shortcodes/class-giphy.php
+++ b/inc/shortcodes/class-giphy.php
@@ -6,32 +6,32 @@ class Giphy extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Giphy', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/png/icon-giphy.png' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Giphy', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/png/icon-giphy.png' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the Giphy', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the Giphy', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Height', 'shortcake-bakery' ),
-					'attr'         => 'height',
-					'type'         => 'number',
-					'description'  => esc_html__( 'Pixel height of the iframe. Defaults to 500.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Height', 'shortcake-bakery' ),
+					'attr'        => 'height',
+					'type'        => 'number',
+					'description' => esc_html__( 'Pixel height of the iframe. Defaults to 500.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Width', 'shortcake-bakery' ),
-					'attr'         => 'width',
-					'type'         => 'number',
-					'description'  => esc_html__( 'Pixel width of the iframe. Defaults to 350.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Width', 'shortcake-bakery' ),
+					'attr'        => 'width',
+					'type'        => 'number',
+					'description' => esc_html__( 'Pixel width of the iframe. Defaults to 350.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Disable Responsiveness', 'shortcake-bakery' ),
-					'attr'         => 'disableresponsiveness',
-					'type'         => 'checkbox',
-					'description'  => esc_html__( 'By default, height/width ratio of Giphy embed will be maintained regardless of container width. Check this to keep constant height/width.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Disable Responsiveness', 'shortcake-bakery' ),
+					'attr'        => 'disableresponsiveness',
+					'type'        => 'checkbox',
+					'description' => esc_html__( 'By default, height/width ratio of Giphy embed will be maintained regardless of container width. Check this to keep constant height/width.', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -46,8 +46,8 @@ class Giphy extends Shortcode {
 					continue;
 				}
 				// Embed ID is the last part of the URL
-				$parts = explode( '/', trim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' ) );
-				$embed_id = array_pop( $parts );
+				$parts           = explode( '/', trim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' ) );
+				$embed_id        = array_pop( $parts );
 				$replacement_key = $iframe->original;
 				// GIPHY embeds can append <p><a href="http://giphy.com/gifs/jtvedit-jtv-rogelio-de-la-vega-ihfrhIgdkQ83C">via GIPHY</a></p>
 				if ( false !== strpos( $iframe->after, '>via GIPHY</a></p>' ) ) {
@@ -59,7 +59,7 @@ class Giphy extends Shortcode {
 						$width_and_or_height .= ' ' . sanitize_key( $attr ) . '="' . (int) $iframe->attrs[ $attr ] . '"';
 					}
 				}
-				$replacement = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( 'http://giphy.com/gifs/' . $embed_id ) . '"' . $width_and_or_height . ']';
+				$replacement                      = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( 'http://giphy.com/gifs/' . $embed_id ) . '"' . $width_and_or_height . ']';
 				$replacements[ $replacement_key ] = $replacement;
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -75,21 +75,22 @@ class Giphy extends Shortcode {
 		}
 
 		$defaults = array(
-			'width'                  => 500,
-			'height'                 => 350,
-			'disableresponsiveness'  => false,
-			);
-		$attrs = array_merge( $defaults, $attrs );
+			'width'                 => 500,
+			'height'                => 350,
+			'disableresponsiveness' => false,
+		);
+		$attrs    = array_merge( $defaults, $attrs );
 
 		// ID is always the last part of the URL
-		$parts = preg_split( '#[-/]#', $attrs['url'], null, PREG_SPLIT_NO_EMPTY );
-		$embed_id = array_pop( $parts );
+		$parts     = preg_split( '#[-/]#', $attrs['url'], null, PREG_SPLIT_NO_EMPTY );
+		$embed_id  = array_pop( $parts );
 		$embed_url = '//giphy.com/embed/' . $embed_id;
-		$classes = 'giphy-embed';
+		$classes   = 'giphy-embed';
 		if ( empty( $attrs['disableresponsiveness'] ) ) {
 			$classes .= ' shortcake-bakery-responsive';
 		}
-		return sprintf( '<iframe src="%s" frameBorder="0" width="%d" height="%d" class="%s" allowFullScreen></iframe>',
+		return sprintf(
+			'<iframe src="%s" frameBorder="0" width="%d" height="%d" class="%s" allowFullScreen></iframe>',
 			esc_url( $embed_url ),
 			(int) $attrs['width'],
 			(int) $attrs['height'],

--- a/inc/shortcodes/class-googledocs.php
+++ b/inc/shortcodes/class-googledocs.php
@@ -8,57 +8,57 @@ class GoogleDocs extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Google Docs', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-googledocs.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Google Docs', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-googledocs.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full document URL', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full document URL', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Height', 'shortcake-bakery' ),
-					'attr'         => 'height',
-					'type'         => 'number',
-					'description'  => esc_html__( 'Pixel height of the iframe.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Height', 'shortcake-bakery' ),
+					'attr'        => 'height',
+					'type'        => 'number',
+					'description' => esc_html__( 'Pixel height of the iframe.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Width', 'shortcake-bakery' ),
-					'attr'         => 'width',
-					'type'         => 'number',
-					'description'  => esc_html__( 'Pixel width of the iframe.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Width', 'shortcake-bakery' ),
+					'attr'        => 'width',
+					'type'        => 'number',
+					'description' => esc_html__( 'Pixel width of the iframe.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Disable Responsiveness', 'shortcake-bakery' ),
-					'attr'         => 'disableresponsiveness',
-					'type'         => 'checkbox',
-					'description'  => esc_html__( 'By default, height/width ratio of the embedded document will be maintained regardless of container width. Check this to keep constant height/width.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Disable Responsiveness', 'shortcake-bakery' ),
+					'attr'        => 'disableresponsiveness',
+					'type'        => 'checkbox',
+					'description' => esc_html__( 'By default, height/width ratio of the embedded document will be maintained regardless of container width. Check this to keep constant height/width.', 'shortcake-bakery' ),
 				),
 
 				/* Options specific to "spreadsheet" document type */
 				array(
-					'label'        => esc_html__( 'Display spreadsheet header rows?', 'shortcake-bakery' ),
-					'attr'         => 'headers',
-					'type'         => 'checkbox',
+					'label' => esc_html__( 'Display spreadsheet header rows?', 'shortcake-bakery' ),
+					'attr'  => 'headers',
+					'type'  => 'checkbox',
 				),
 
 				/* Options specific to "presentation" document type */
 				array(
-					'label'        => esc_html__( 'Autostart?', 'shortcake-bakery' ),
-					'attr'         => 'start',
-					'type'         => 'checkbox',
+					'label' => esc_html__( 'Autostart?', 'shortcake-bakery' ),
+					'attr'  => 'start',
+					'type'  => 'checkbox',
 				),
 				array(
-					'label'        => esc_html__( 'Loop?', 'shortcake-bakery' ),
-					'attr'         => 'loop',
-					'type'         => 'checkbox',
+					'label' => esc_html__( 'Loop?', 'shortcake-bakery' ),
+					'attr'  => 'loop',
+					'type'  => 'checkbox',
 				),
 				array(
-					'label'        => esc_html__( 'Delay between slides (ms)', 'shortcake-bakery' ),
-					'attr'         => 'delayms',
-					'type'         => 'number',
-					'default'      => 3000,
+					'label'   => esc_html__( 'Delay between slides (ms)', 'shortcake-bakery' ),
+					'attr'    => 'delayms',
+					'type'    => 'number',
+					'default' => 3000,
 				),
 			),
 		);
@@ -79,7 +79,7 @@ class GoogleDocs extends Shortcode {
 
 				switch ( $parsed_from_url['doc_type'] ) {
 					case 'document':
-						$replacement_url = 'https://docs.google.com/document/d/' . $parsed_from_url['embed_id'];
+						$replacement_url                   = 'https://docs.google.com/document/d/' . $parsed_from_url['embed_id'];
 						$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() .
 							' url="' . esc_url_raw( $replacement_url ) . '"' .
 							( ! empty( $iframe->attrs['height'] ) ? ' height=' . intval( $iframe->attrs['height'] ) : '' ) .
@@ -89,7 +89,7 @@ class GoogleDocs extends Shortcode {
 					case 'spreadsheet':
 					case 'spreadsheets':
 						parse_str( html_entity_decode( $parsed_from_url['query_string'] ), $query_vars );
-						$replacement_url = 'https://docs.google.com/spreadsheets/d/' . $parsed_from_url['embed_id'];
+						$replacement_url                   = 'https://docs.google.com/spreadsheets/d/' . $parsed_from_url['embed_id'];
 						$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() .
 							' url="' . esc_url_raw( $replacement_url ) . '"' .
 							( ! empty( $iframe->attrs['height'] ) ? ' height=' . intval( $iframe->attrs['height'] ) : '' ) .
@@ -99,7 +99,7 @@ class GoogleDocs extends Shortcode {
 						break;
 					case 'presentation':
 						parse_str( html_entity_decode( $parsed_from_url['query_string'] ), $query_vars );
-						$replacement_url = 'https://docs.google.com/presentation/d/' . $parsed_from_url['embed_id'];
+						$replacement_url                   = 'https://docs.google.com/presentation/d/' . $parsed_from_url['embed_id'];
 						$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() .
 							' url="' . esc_url_raw( $replacement_url ) . '"' .
 							( ! empty( $iframe->attrs['height'] ) ? ' height=' . intval( $iframe->attrs['height'] ) : '' ) .
@@ -111,7 +111,7 @@ class GoogleDocs extends Shortcode {
 						break;
 					case 'form':
 					case 'forms':
-						$replacement_url = 'https://docs.google.com/forms/d/' . $parsed_from_url['embed_id'];
+						$replacement_url                   = 'https://docs.google.com/forms/d/' . $parsed_from_url['embed_id'];
 						$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() .
 							' url="' . esc_url_raw( $replacement_url ) . '"' .
 							( ! empty( $iframe->attrs['height'] ) ? ' height=' . intval( $iframe->attrs['height'] ) : '' ) .
@@ -124,7 +124,7 @@ class GoogleDocs extends Shortcode {
 						if ( empty( $query_vars['mid'] ) ) {
 							return;
 						}
-						$replacement_url = add_query_arg(
+						$replacement_url                   = add_query_arg(
 							array(
 								'mid' => $query_vars['mid'],
 							),
@@ -138,7 +138,7 @@ class GoogleDocs extends Shortcode {
 						break;
 					case 'fusiontables':
 						parse_str( html_entity_decode( $parsed_from_url['query_string'] ), $query_vars );
-						$replacement_url = add_query_arg( $query_vars, 'https://www.google.com/fusiontables/embedviz' );
+						$replacement_url                   = add_query_arg( $query_vars, 'https://www.google.com/fusiontables/embedviz' );
 						$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() .
 							' url="' . esc_url_raw( $replacement_url ) . '"' .
 							( ! empty( $iframe->attrs['height'] ) ? ' height=' . intval( $iframe->attrs['height'] ) : '' ) .
@@ -161,16 +161,16 @@ class GoogleDocs extends Shortcode {
 			return '';
 		}
 
-		$iframe_classes = "shortcake-bakery-googledocs-{$type}" .
+		$iframe_classes        = "shortcake-bakery-googledocs-{$type}" .
 			( empty( $attrs['disableresponsiveness'] ) ? ' shortcake-bakery-responsive' : '' );
-		$url = '';
-		$inner_content = '';
-		$width_attr  = ! empty( $attrs['width'] )  ? intval( $attrs['width'] ) : '';
-		$height_attr = ! empty( $attrs['height'] ) ? intval( $attrs['height'] ) : '';
+		$url                   = '';
+		$inner_content         = '';
+		$width_attr            = ! empty( $attrs['width'] ) ? intval( $attrs['width'] ) : '';
+		$height_attr           = ! empty( $attrs['height'] ) ? intval( $attrs['height'] ) : '';
 		$additional_attributes = array(
-			'frameborder' => '0',
+			'frameborder'  => '0',
 			'marginheight' => '0',
-			'marginwidth' => '0',
+			'marginwidth'  => '0',
 		);
 
 		switch ( $type ) {
@@ -185,29 +185,29 @@ class GoogleDocs extends Shortcode {
 			case 'spreadsheet':
 				$url = add_query_arg(
 					array(
-						'widget' => 'true',
+						'widget'  => 'true',
 						'headers' => ! empty( $attrs['headers'] ) ? 'true' : 'false',
 					),
 					$attrs['url'] . '/pubhtml'
 				);
 				break;
 			case 'presentation':
-				$url = add_query_arg(
+				$url                   = add_query_arg(
 					array(
-						'start' => ! empty( $attrs['start'] ) ? 'true' : 'false',
-						'loop' => ! empty( $attrs['loop'] ) ? 'true' : 'false',
+						'start'   => ! empty( $attrs['start'] ) ? 'true' : 'false',
+						'loop'    => ! empty( $attrs['loop'] ) ? 'true' : 'false',
 						'delayms' => ! empty( $attrs['delayms'] ) ? intval( $attrs['delayms'] ) : '3000',
 					),
 					$attrs['url'] . '/embed'
 				);
 				$additional_attributes = array(
-					'allowfullscreen' => 'true',
-					'mozallowfullscreen' => 'true',
+					'allowfullscreen'       => 'true',
+					'mozallowfullscreen'    => 'true',
 					'webkitallowfullscreen' => 'true',
 				);
 				break;
 			case 'form':
-				$url = add_query_arg(
+				$url           = add_query_arg(
 					array(
 						'embedded' => 'true',
 					),
@@ -227,7 +227,7 @@ class GoogleDocs extends Shortcode {
 
 		return '<iframe class="' . esc_attr( $iframe_classes ) . '" ' .
 			'src="' . esc_url( $url ) . '" ' .
-			( $width_attr ? 'width="' . esc_attr( $width_attr ) . '" ' : '') .
+			( $width_attr ? 'width="' . esc_attr( $width_attr ) . '" ' : '' ) .
 			( $height_attr ? 'height="' . esc_attr( $height_attr ) . '" ' : '' ) .
 			( $additional_attributes ? array_reduce(
 				array_keys( $additional_attributes ),

--- a/inc/shortcodes/class-guardian.php
+++ b/inc/shortcodes/class-guardian.php
@@ -6,14 +6,14 @@ class Guardian extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'The Guardian', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-guardian.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'The Guardian', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-guardian.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to a Guardian video', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to a Guardian video', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -27,8 +27,8 @@ class Guardian extends Shortcode {
 				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'embed.theguardian.com' ), true ) ) {
 					continue;
 				}
-				$path = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
-				$url = 'http://www.theguardian.com' . preg_replace( '#^/embed/video/#', '/', $path );
+				$path                              = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
+				$url                               = 'http://www.theguardian.com' . preg_replace( '#^/embed/video/#', '/', $path );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -44,7 +44,7 @@ class Guardian extends Shortcode {
 		}
 
 		$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
-		$url = 'https://embed.theguardian.com/embed/video' . $path;
+		$url  = 'https://embed.theguardian.com/embed/video' . $path;
 		return sprintf( '<iframe class="shortcake-bakery-responsive" width="560" height="315" src="%s" frameborder="0"></iframe>', esc_url( $url ) );
 	}
 

--- a/inc/shortcodes/class-iframe.php
+++ b/inc/shortcodes/class-iframe.php
@@ -6,32 +6,32 @@ class Iframe extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Iframe', 'shortcake-bakery' ),
-			'listItemImage'  => 'dashicons-admin-site',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Iframe', 'shortcake-bakery' ),
+			'listItemImage' => 'dashicons-admin-site',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'src',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the iFrame source. Host must be whitelisted.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'src',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the iFrame source. Host must be whitelisted.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Height', 'shortcake-bakery' ),
-					'attr'         => 'height',
-					'type'         => 'number',
-					'description'  => esc_html__( 'Pixel height of the iframe. Defaults to 600.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Height', 'shortcake-bakery' ),
+					'attr'        => 'height',
+					'type'        => 'number',
+					'description' => esc_html__( 'Pixel height of the iframe. Defaults to 600.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Width', 'shortcake-bakery' ),
-					'attr'         => 'width',
-					'type'         => 'number',
-					'description'  => esc_html__( 'Pixel width of the iframe. Defaults to 670.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Width', 'shortcake-bakery' ),
+					'attr'        => 'width',
+					'type'        => 'number',
+					'description' => esc_html__( 'Pixel width of the iframe. Defaults to 670.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Disable Responsiveness', 'shortcake-bakery' ),
-					'attr'         => 'disableresponsiveness',
-					'type'         => 'checkbox',
-					'description'  => esc_html__( 'By default, height/width ratio of iframe will be maintained regardless of container width. Check this to keep constant height/width.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Disable Responsiveness', 'shortcake-bakery' ),
+					'attr'        => 'disableresponsiveness',
+					'type'        => 'checkbox',
+					'description' => esc_html__( 'By default, height/width ratio of iframe will be maintained regardless of container width. Check this to keep constant height/width.', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -59,7 +59,7 @@ class Iframe extends Shortcode {
 		$iframes = self::parse_iframes( $content );
 		if ( $iframes ) {
 			$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
-			$replacements = array();
+			$replacements               = array();
 			foreach ( $iframes as $iframe ) {
 				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), $whitelisted_iframe_domains, true ) ) {
 					continue;
@@ -78,11 +78,11 @@ class Iframe extends Shortcode {
 		}
 
 		$defaults = array(
-			'height'                  => 600,
-			'width'                   => 670,
-			'disableresponsiveness'   => false,
-			);
-		$attrs = array_merge( $defaults, $attrs );
+			'height'                => 600,
+			'width'                 => 670,
+			'disableresponsiveness' => false,
+		);
+		$attrs    = array_merge( $defaults, $attrs );
 
 		// Allow iFrame URLs to be filtered
 		$attrs['src'] = apply_filters( 'shortcake_bakery_iframe_src', $attrs['src'], $attrs );

--- a/inc/shortcodes/class-image-comparison.php
+++ b/inc/shortcodes/class-image-comparison.php
@@ -6,32 +6,32 @@ class Image_Comparison extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Image Comparison', 'shortcake-bakery' ),
-			'listItemImage'  => 'dashicons-format-gallery',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Image Comparison', 'shortcake-bakery' ),
+			'listItemImage' => 'dashicons-format-gallery',
+			'attrs'         => array(
 				array(
-					'label'  => esc_html__( 'Left Image', 'shortcake-bakery' ),
-					'attr'   => 'left',
-					'type'   => 'attachment',
+					'label'       => esc_html__( 'Left Image', 'shortcake-bakery' ),
+					'attr'        => 'left',
+					'type'        => 'attachment',
 					'libraryType' => array( 'image' ),
 					'addButton'   => esc_html__( 'Select Image', 'shortcake-bakery' ),
 					'frameTitle'  => esc_html__( 'Select Image', 'shortcake-bakery' ),
-					),
+				),
 				array(
-					'label'  => esc_html__( 'Right Image', 'shortcake-bakery' ),
-					'attr'   => 'right',
-					'type'   => 'attachment',
+					'label'       => esc_html__( 'Right Image', 'shortcake-bakery' ),
+					'attr'        => 'right',
+					'type'        => 'attachment',
 					'libraryType' => array( 'image' ),
 					'addButton'   => esc_html__( 'Select Image', 'shortcake-bakery' ),
 					'frameTitle'  => esc_html__( 'Select Image', 'shortcake-bakery' ),
-					),
+				),
 				array(
-					'label'  => esc_html__( 'Slider Start Position', 'shortcake-bakery' ),
-					'attr'   => 'position',
-					'type'   => 'select',
+					'label'   => esc_html__( 'Slider Start Position', 'shortcake-bakery' ),
+					'attr'    => 'position',
+					'type'    => 'select',
 					'options' => array(
-						'center' => esc_html__( 'Center', 'shortcake-bakery' ),
-						'mostlyleft' => esc_html__( 'Mostly Left', 'shortcake-bakery' ),
+						'center'      => esc_html__( 'Center', 'shortcake-bakery' ),
+						'mostlyleft'  => esc_html__( 'Mostly Left', 'shortcake-bakery' ),
 						'mostlyright' => esc_html__( 'Mostly Right', 'shortcake-bakery' ),
 					),
 				),
@@ -41,12 +41,14 @@ class Image_Comparison extends Shortcode {
 
 	public static function setup_actions() {
 		add_action( 'wp_enqueue_scripts', 'Shortcake_Bakery\Shortcodes\Image_Comparison::action_init_register_scripts' );
-		add_action( 'shortcode_ui_after_do_shortcode', function( $shortcode ) {
-			if ( false !== stripos( $shortcode, '[' . self::get_shortcode_tag() ) ) {
-				echo '<link rel="stylesheet" href="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/css/juxtapose.css' ) . '">';
-				echo '<script type="text/javascript" src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/js/juxtapose.js' ) . '"></script>';
+		add_action(
+			'shortcode_ui_after_do_shortcode', function( $shortcode ) {
+				if ( false !== stripos( $shortcode, '[' . self::get_shortcode_tag() ) ) {
+					echo '<link rel="stylesheet" href="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/css/juxtapose.css' ) . '">';
+					echo '<script type="text/javascript" src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/js/juxtapose.js' ) . '"></script>';
+				}
 			}
-		});
+		);
 	}
 
 	public static function action_init_register_scripts() {
@@ -64,34 +66,34 @@ class Image_Comparison extends Shortcode {
 		}
 
 		if ( empty( $attrs['position'] ) ) {
-			 $attrs['position'] = 'center';
+			$attrs['position'] = 'center';
 		}
 
 		switch ( $attrs['position'] ) {
 
-			case 'center' :
+			case 'center':
 				$attrs['position'] = 50;
 				break;
 
-			case 'mostlyleft' :
+			case 'mostlyleft':
 				$attrs['position'] = 10;
 				break;
 
-			case 'mostlyright' :
+			case 'mostlyright':
 				$attrs['position'] = 90;
 				break;
 
 		}
 
-		$left_image = wp_get_attachment_image_src( $attrs['left'], 'large', false );
+		$left_image  = wp_get_attachment_image_src( $attrs['left'], 'large', false );
 		$right_image = wp_get_attachment_image_src( $attrs['right'], 'large', false );
 
-		$left_caption = get_post_field( 'post_excerpt', $attrs['left'] );
+		$left_caption  = get_post_field( 'post_excerpt', $attrs['left'] );
 		$right_caption = get_post_field( 'post_excerpt', $attrs['right'] );
 
-		$left_meta = wp_get_attachment_metadata( $attrs['left'] );
-		$right_meta = wp_get_attachment_metadata( $attrs['right'] );
-		$left_credit = $left_meta['image_meta']['credit'];
+		$left_meta    = wp_get_attachment_metadata( $attrs['left'] );
+		$right_meta   = wp_get_attachment_metadata( $attrs['right'] );
+		$left_credit  = $left_meta['image_meta']['credit'];
 		$right_credit = $right_meta['image_meta']['credit'];
 
 		if ( ! $left_image || ! $right_image ) {
@@ -102,7 +104,7 @@ class Image_Comparison extends Shortcode {
 		wp_enqueue_style( 'juxtapose-css' );
 
 		/* Begin container */
-		$out = '<section class="image-comparison">';
+		$out  = '<section class="image-comparison">';
 		$out .= '<div class="juxtapose" data-startingposition="';
 		$out .= esc_attr( $attrs['position'] );
 		$out .= '" data-showlabels="true" data-showcredits="true" data-animate="true">';

--- a/inc/shortcodes/class-infogram.php
+++ b/inc/shortcodes/class-infogram.php
@@ -11,14 +11,14 @@ class Infogram extends Shortcode {
 	 */
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Infogram', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-infogram.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Infogram', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-infogram.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to the Infogram', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to the Infogram', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -41,7 +41,7 @@ class Infogram extends Shortcode {
 				if ( empty( $script->attrs['id'] ) ) {
 					continue;
 				}
-				$url_string = str_replace( 'infogram_0_', '', $script->attrs['id'] );
+				$url_string                        = str_replace( 'infogram_0_', '', $script->attrs['id'] );
 				$replacements[ $script->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url( 'https://infogr.am/' . $url_string ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -53,7 +53,7 @@ class Infogram extends Shortcode {
 				if ( 'e.infogr.am' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
-				$url_string = ltrim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' );
+				$url_string                        = ltrim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url( 'https://infogr.am/' . $url_string ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -72,8 +72,8 @@ class Infogram extends Shortcode {
 		if ( empty( $attrs['url'] ) ) {
 			return '';
 		}
-		$id = preg_replace( '((http|https)\:\/\/infogr\.am\/)', '', $attrs['url'] );
-		$out = '<script async src="//e.infogr.am/js/embed.js" id="infogram_0_';
+		$id   = preg_replace( '((http|https)\:\/\/infogr\.am\/)', '', $attrs['url'] );
+		$out  = '<script async src="//e.infogr.am/js/embed.js" id="infogram_0_';
 		$out .= esc_attr( $id );
 		$out .= '" type="text/javascript"></script>';
 		return $out;

--- a/inc/shortcodes/class-instagram.php
+++ b/inc/shortcodes/class-instagram.php
@@ -6,14 +6,14 @@ class Instagram extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Instagram', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-instagram.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Instagram', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-instagram.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to an Instagram', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to an Instagram', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -27,7 +27,7 @@ class Instagram extends Shortcode {
 
 		$needle = '#<blockquote class="instagram-media.+<a href="(https://(www\.)?instagram\.com/p/[^/]+/)"[^>]+>.+(?=</blockquote>)</blockquote>\n?(<script[^>]+src="//platform\.instagram\.com/[^>]+></script>)?#';
 		if ( preg_match_all( $needle, $content, $matches ) ) {
-			$replacements = array();
+			$replacements  = array();
 			$shortcode_tag = self::get_shortcode_tag();
 			foreach ( $matches[0] as $key => $value ) {
 				$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[1][ $key ] ) . '"]';
@@ -67,7 +67,8 @@ class Instagram extends Shortcode {
 			return '';
 		}
 
-		return sprintf( '<iframe class="shortcake-bakery-responsive" src="%s" width="612" height="710" frameborder="0" scrolling="no"></iframe>',
+		return sprintf(
+			'<iframe class="shortcake-bakery-responsive" src="%s" width="612" height="710" frameborder="0" scrolling="no"></iframe>',
 			esc_url( sprintf( 'https://instagram.com/p/%s/embed/', $photo_id ) )
 		);
 	}

--- a/inc/shortcodes/class-live-photo.php
+++ b/inc/shortcodes/class-live-photo.php
@@ -6,21 +6,21 @@ class Live_Photo extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Live Photo', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/png/icon-live-photo.png' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Live Photo', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/png/icon-live-photo.png' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'  => esc_html__( 'Live Photo Image', 'shortcake-bakery' ),
-					'attr'   => 'live-photo-image',
-					'type'   => 'attachment',
+					'label'       => esc_html__( 'Live Photo Image', 'shortcake-bakery' ),
+					'attr'        => 'live-photo-image',
+					'type'        => 'attachment',
 					'libraryType' => array( 'image' ),
 					'addButton'   => esc_html__( 'Select Live Photo Image', 'shortcake-bakery' ),
 					'frameTitle'  => esc_html__( 'Select Live Photo Image', 'shortcake-bakery' ),
 				),
 				array(
-					'label'  => esc_html__( 'Live Photo Movie', 'shortcake-bakery' ),
-					'attr'   => 'live-photo-movie',
-					'type'   => 'attachment',
+					'label'       => esc_html__( 'Live Photo Movie', 'shortcake-bakery' ),
+					'attr'        => 'live-photo-movie',
+					'type'        => 'attachment',
 					'libraryType' => array( 'video' ),
 					'addButton'   => esc_html__( 'Select Live Photo Movie', 'shortcake-bakery' ),
 					'frameTitle'  => esc_html__( 'Select Live Photo Movie', 'shortcake-bakery' ),
@@ -31,11 +31,13 @@ class Live_Photo extends Shortcode {
 
 	public static function setup_actions() {
 		add_action( 'wp_enqueue_scripts', 'Shortcake_Bakery\Shortcodes\Live_Photo::action_init_register_scripts' );
-		add_action( 'shortcode_ui_after_do_shortcode', function( $shortcode ) {
-			if ( false !== stripos( $shortcode, '[' . self::get_shortcode_tag() ) ) {
-				echo '<script type="text/javascript" src="' . esc_url( 'https://cdn.apple-livephotoskit.com/lpk/1/livephotoskit.js' ) . '"></script>';
+		add_action(
+			'shortcode_ui_after_do_shortcode', function( $shortcode ) {
+				if ( false !== stripos( $shortcode, '[' . self::get_shortcode_tag() ) ) {
+					echo '<script type="text/javascript" src="' . esc_url( 'https://cdn.apple-livephotoskit.com/lpk/1/livephotoskit.js' ) . '"></script>';
+				}
 			}
-		});
+		);
 	}
 
 	public static function action_init_register_scripts() {

--- a/inc/shortcodes/class-livestream.php
+++ b/inc/shortcodes/class-livestream.php
@@ -8,14 +8,14 @@ class Livestream extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Livestream', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-livestream.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Livestream', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-livestream.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the Livestream', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the Livestream', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -30,9 +30,9 @@ class Livestream extends Shortcode {
 					continue;
 				}
 				// URL looks like: http://new.livestream.com/accounts/9035483/events/3424523/videos/64460770/player?width=480&height=270&autoPlay=false&mute=false
-				$path = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
-				$path = preg_replace( '#/player/?$#', '/', $path );
-				$url = 'https://livestream.com' . $path;
+				$path                              = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
+				$path                              = preg_replace( '#/player/?$#', '/', $path );
+				$url                               = 'https://livestream.com' . $path;
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );

--- a/inc/shortcodes/class-pdf.php
+++ b/inc/shortcodes/class-pdf.php
@@ -6,9 +6,9 @@ class PDF extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		$shortcode_attrs = array(
-			'label'          => esc_html__( 'PDF', 'shortcake-bakery' ),
-			'listItemImage'  => 'dashicons-media-document',
-			'attrs'          => array(
+			'label'         => esc_html__( 'PDF', 'shortcake-bakery' ),
+			'listItemImage' => 'dashicons-media-document',
+			'attrs'         => array(
 				array(
 					'label'       => esc_html__( 'Select or upload PDF', 'shortcake-bakery' ),
 					'attr'        => 'attachment',
@@ -16,9 +16,9 @@ class PDF extends Shortcode {
 					'libraryType' => 'application/pdf',
 				),
 				array(
-					'label'       => esc_html__( '...or embed from URL', 'shortcake-bakery' ),
-					'attr'        => 'url',
-					'type'        => 'text',
+					'label' => esc_html__( '...or embed from URL', 'shortcake-bakery' ),
+					'attr'  => 'url',
+					'type'  => 'text',
 				),
 			),
 		);
@@ -32,9 +32,9 @@ class PDF extends Shortcode {
 		if ( apply_filters( 'shortcake_bakery_pdf_enable_cors_proxy', false ) ) {
 
 			$shortcode_attrs['attrs'][] = array(
-				'label'  => esc_html__( 'Proxy through local domain?', 'shortcake-bakery' ),
-				'attr'   => 'proxy',
-				'type'   => 'checkbox',
+				'label'       => esc_html__( 'Proxy through local domain?', 'shortcake-bakery' ),
+				'attr'        => 'proxy',
+				'type'        => 'checkbox',
 				'description' => esc_html__(
 					"External PDFs require proper Access-Control headers in order to embed. \nIf you are seeing 'An error occurred while loading the PDF' errors, try this.",
 					'shortcake-bakery'
@@ -98,8 +98,8 @@ class PDF extends Shortcode {
 			return '';
 		}
 
-		$url_for_parse = ( 0 === strpos( $url, '//' ) ) ? 'http:' . $url :  $url;
-		$scheme = self::parse_url( $url_for_parse, PHP_URL_SCHEME );
+		$url_for_parse = ( 0 === strpos( $url, '//' ) ) ? 'http:' . $url : $url;
+		$scheme        = self::parse_url( $url_for_parse, PHP_URL_SCHEME );
 
 		$ext = pathinfo( $url, PATHINFO_EXTENSION );
 		if ( 'pdf' !== strtolower( $ext ) ) {
@@ -111,7 +111,7 @@ class PDF extends Shortcode {
 		}
 
 		$viewer_url = SHORTCAKE_BAKERY_URL_ROOT . 'assets/lib/pdfjs/web/viewer.html';
-		$source = add_query_arg( 'file', rawurlencode( $url ), $viewer_url );
+		$source     = add_query_arg( 'file', rawurlencode( $url ), $viewer_url );
 
 		return '<iframe class="shortcake-bakery-responsive" data-true-height="800px" data-true-width="600px" width="600px" height="800px" frameBorder="0" src="' . esc_url( $source ) . '"></iframe>';
 	}

--- a/inc/shortcodes/class-playbuzz.php
+++ b/inc/shortcodes/class-playbuzz.php
@@ -6,30 +6,30 @@ class Playbuzz extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label' 		=> 'Playbuzz',
+			'label'         => 'Playbuzz',
 			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-playbuzz.svg' ) . '" />',
-			'attrs' 		=> array(
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'Playbuzz quiz URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'The full URL to the Playbuzz quiz (e.g. https://www.playbuzz.com/Fusion/5-mind-blowing-facts-about-cloning-from-jurassic-park-youll-never-believe-actually-exist-in-real)', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'Playbuzz quiz URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'The full URL to the Playbuzz quiz (e.g. https://www.playbuzz.com/Fusion/5-mind-blowing-facts-about-cloning-from-jurassic-park-youll-never-believe-actually-exist-in-real)', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Display recommendations for more games', 'shortcake-bakery' ),
-					'attr'         => 'recommend',
-					'type'         => 'checkbox',
-					),
+					'label' => esc_html__( 'Display recommendations for more games', 'shortcake-bakery' ),
+					'attr'  => 'recommend',
+					'type'  => 'checkbox',
+				),
 				array(
-					'label'        => esc_html__( 'Display share buttons', 'shortcake-bakery' ),
-					'attr'         => 'shares',
-					'type'         => 'checkbox',
-					),
+					'label' => esc_html__( 'Display share buttons', 'shortcake-bakery' ),
+					'attr'  => 'shares',
+					'type'  => 'checkbox',
+				),
 				array(
-					'label'        => esc_html__( 'Use Facebook comments', 'shortcake-bakery' ),
-					'attr'         => 'comments',
-					'type'         => 'checkbox',
-					),
+					'label' => esc_html__( 'Use Facebook comments', 'shortcake-bakery' ),
+					'attr'  => 'comments',
+					'type'  => 'checkbox',
+				),
 			),
 		);
 	}
@@ -41,16 +41,16 @@ class Playbuzz extends Shortcode {
 		}
 
 		if ( preg_match_all( '#<script([^>]+)src=["\']//cdn\.playbuzz\.com([^>]+)></script>\r?\n?<div([^>]+)class=["\']pb_feed["\']([^>]+)></div>#', $content, $matches ) ) {
-			$replacements = array();
+			$replacements  = array();
 			$shortcode_tag = self::get_shortcode_tag();
 			foreach ( $matches[0] as $key => $value ) {
 
-				$div_parts = explode( ' ', $matches[4][ $key ] );
+				$div_parts       = explode( ' ', $matches[4][ $key ] );
 				$shortcode_attrs = array();
 				foreach ( $div_parts as $div_part ) {
 					$attr_parts = explode( '=', $div_part );
-					$key = array_shift( $attr_parts );
-					$val = ! empty( $attr_parts[0] ) ? trim( $attr_parts[0], '\'"' ) : false;
+					$key        = array_shift( $attr_parts );
+					$val        = ! empty( $attr_parts[0] ) ? trim( $attr_parts[0], '\'"' ) : false;
 					if ( empty( $val ) ) {
 						continue;
 					}
@@ -78,7 +78,7 @@ class Playbuzz extends Shortcode {
 				foreach ( $shortcode_attrs as $key => $val ) {
 					$attrs_string .= $key . '="' . $val . '" ';
 				}
-				$attrs_string = rtrim( $attrs_string );
+				$attrs_string           = rtrim( $attrs_string );
 				$replacements[ $value ] = '[' . $shortcode_tag . ' ' . $attrs_string . ']';
 			} // End foreach().
 
@@ -98,9 +98,9 @@ class Playbuzz extends Shortcode {
 		}
 
 		$playbuzz_args = array(
-			'game'     => self::parse_url( $attrs['url'], PHP_URL_PATH ),
-			'height'   => 'auto',
-			);
+			'game'   => self::parse_url( $attrs['url'], PHP_URL_PATH ),
+			'height' => 'auto',
+		);
 
 		foreach ( array( 'recommend', 'comments', 'shares' ) as $key ) {
 			$playbuzz_args[ $key ] = ! empty( $attrs[ $key ] ) && 'true' === $attrs[ $key ] ? 'true' : 'false';
@@ -108,7 +108,7 @@ class Playbuzz extends Shortcode {
 
 		if ( is_admin() ) {
 			$playbuzz_args['feed'] = 'true';
-			$embed_url = add_query_arg( $playbuzz_args, $attrs['url'] );
+			$embed_url             = add_query_arg( $playbuzz_args, $attrs['url'] );
 			return '<iframe width="100%" height="300px" src="' . esc_url( $embed_url ) . '" frameborder="0"></iframe>';
 		} else {
 			wp_enqueue_script( 'playbuzz-widget', '//cdn.playbuzz.com/widget/feed.js' );

--- a/inc/shortcodes/class-rap-genius.php
+++ b/inc/shortcodes/class-rap-genius.php
@@ -6,8 +6,8 @@ class Rap_Genius extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Rap Genius', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-rapgenius.svg' ) . '" />',
+			'label'         => esc_html__( 'Rap Genius', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-rapgenius.svg' ) . '" />',
 		);
 	}
 

--- a/inc/shortcodes/class-scribd.php
+++ b/inc/shortcodes/class-scribd.php
@@ -6,14 +6,14 @@ class Scribd extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Scribd', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-scribd.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Scribd', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-scribd.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the Scribd document', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the Scribd document', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -28,8 +28,8 @@ class Scribd extends Shortcode {
 					continue;
 				}
 				// URL looks like: https://www.scribd.com/embeds/272220183/content?start_page=1&amp;view_mode=scroll&amp;show_recommendations=true
-				$url = explode( 'content?', $iframe->attrs['src'] );
-				$url = str_replace( '/embeds/', '/doc/', $url[0] );
+				$url                               = explode( 'content?', $iframe->attrs['src'] );
+				$url                               = str_replace( '/embeds/', '/doc/', $url[0] );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -52,10 +52,10 @@ class Scribd extends Shortcode {
 			}
 		}
 		$exploded_url = explode( '/', $needle[0] );
-		$id = $exploded_url[4];
+		$id           = $exploded_url[4];
 
-		$url = 'https://www.scribd.com/embeds/' . $id . '/content?start_page=1&view_mode=scroll&access_key=key-ooxdrkmSg8ieauz9qYXL&show_recommendations=true';
-		$out = '<iframe class="scribd_iframe_embed shortcake-bakery-responsive" src="';
+		$url  = 'https://www.scribd.com/embeds/' . $id . '/content?start_page=1&view_mode=scroll&access_key=key-ooxdrkmSg8ieauz9qYXL&show_recommendations=true';
+		$out  = '<iframe class="scribd_iframe_embed shortcake-bakery-responsive" src="';
 		$out .= esc_url( $url );
 		$out .= '" data-auto-height="false" data-aspect-ratio="0.7631133671742809" scrolling="no" width="100%" height="600" frameborder="0"></iframe>';
 		return $out;

--- a/inc/shortcodes/class-script.php
+++ b/inc/shortcodes/class-script.php
@@ -6,14 +6,14 @@ class Script extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Script', 'shortcake-bakery' ),
-			'listItemImage'  => 'dashicons-media-code',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Script', 'shortcake-bakery' ),
+			'listItemImage' => 'dashicons-media-code',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'src',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the script file. Host must be whitelisted.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'src',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the script file. Host must be whitelisted.', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -34,9 +34,9 @@ class Script extends Shortcode {
 	public static function reversal( $content ) {
 		$scripts = self::parse_scripts( $content );
 		if ( $scripts ) {
-			$replacements = array();
+			$replacements               = array();
 			$whitelisted_script_domains = static::get_whitelisted_script_domains();
-			$shortcode_tag = static::get_shortcode_tag();
+			$shortcode_tag              = static::get_shortcode_tag();
 			foreach ( $scripts as $script ) {
 				$host = self::parse_url( $script->attrs['src'], PHP_URL_HOST );
 				if ( ! in_array( $host, $whitelisted_script_domains, true ) ) {

--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -14,7 +14,7 @@ abstract class Shortcode {
 	 * @return string
 	 */
 	public static function get_shortcode_tag() {
-		$parts = explode( '\\', get_called_class() );
+		$parts         = explode( '\\', get_called_class() );
 		$shortcode_tag = array_pop( $parts );
 		$shortcode_tag = strtolower( str_replace( '_', '-', $shortcode_tag ) );
 		return apply_filters( 'shortcake_bakery_shortcode_tag', $shortcode_tag, get_called_class() );
@@ -65,7 +65,7 @@ abstract class Shortcode {
 	protected static function parse_url( $url, $component = -1 ) {
 		$added_protocol = false;
 		if ( 0 === strpos( $url, '//' ) ) {
-			$url = 'http:' . $url;
+			$url            = 'http:' . $url;
 			$added_protocol = true;
 		}
 		// @codingStandardsIgnoreStart
@@ -97,16 +97,16 @@ abstract class Shortcode {
 		if ( preg_match_all( '#(.+\r?\n?)?(<' . $tag_name . '([^>]+)>([^<]+)?</' . $tag_name . '>)(\r?\n?.+)?#', $content, $matches ) ) {
 			$tags = array();
 			foreach ( $matches[0] as $key => $value ) {
-				$tag = new \stdClass;
+				$tag           = new \stdClass;
 				$tag->original = $matches[2][ $key ];
-				$tag->before = $matches[1][ $key ];
-				$tag->attrs = array(
+				$tag->before   = $matches[1][ $key ];
+				$tag->attrs    = array(
 					'src' => '',
 				);
-				$tag->inner = $matches[4][ $key ];
-				$tag->after = $matches[5][ $key ];
-				$tag->attrs = self::parse_tag_attributes( $matches[3][ $key ] );
-				$tags[] = $tag;
+				$tag->inner    = $matches[4][ $key ];
+				$tag->after    = $matches[5][ $key ];
+				$tag->attrs    = self::parse_tag_attributes( $matches[3][ $key ] );
+				$tags[]        = $tag;
 			}
 			return $tags;
 		} else {
@@ -144,8 +144,8 @@ abstract class Shortcode {
 	 */
 	protected static function parse_tag_attributes( $text ) {
 		$pattern = '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/';
-		$text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $text );
-		$atts = array();
+		$text    = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $text );
+		$atts    = array();
 
 		if ( preg_match_all( $pattern, $text, $match, PREG_SET_ORDER ) ) {
 			foreach ( $match as $m ) {

--- a/inc/shortcodes/class-silk.php
+++ b/inc/shortcodes/class-silk.php
@@ -6,26 +6,26 @@ class Silk extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Silk', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-silk.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Silk', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-silk.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the Silk', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the Silk', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Size', 'shortcake-bakery' ),
-					'attr'         => 'size',
-					'type'         => 'select',
-					'options'      => array(
+					'label'   => esc_html__( 'Size', 'shortcake-bakery' ),
+					'attr'    => 'size',
+					'type'    => 'select',
+					'options' => array(
 						'responsive' => esc_html__( 'Responsive (square)' ),
-						'800x100%'  => esc_html__( '800px height, 100% width' ),
-						'600x100%'  => esc_html__( '600px height, 100% width' ),
-						'400x100%'  => esc_html__( '400px height, 100% width' ),
-						),
+						'800x100%'   => esc_html__( '800px height, 100% width' ),
+						'600x100%'   => esc_html__( '600px height, 100% width' ),
+						'400x100%'   => esc_html__( '400px height, 100% width' ),
 					),
+				),
 			),
 		);
 	}
@@ -60,23 +60,24 @@ class Silk extends Shortcode {
 		// Force Silk embeds over HTTPS just in case
 		$attrs['url'] = set_url_scheme( $attrs['url'], 'https' );
 
-		$height = 600;
-		$width = 600;
+		$height  = 600;
+		$width   = 600;
 		$classes = 'shortcake-bakery-responsive';
 
 		if ( ! empty( $attrs['size'] ) && stripos( $attrs['size'], 'x' ) ) {
 			$parts = explode( 'x', $attrs['size'] );
 			if ( count( $parts ) === 2 ) {
 				foreach ( array( 'height', 'width' ) as $key => $variable ) {
-					$ending = stripos( $parts[ $key ], '%' ) ? '%' : '';
-					$value = rtrim( $parts[ $key ], '%' );
+					$ending    = stripos( $parts[ $key ], '%' ) ? '%' : '';
+					$value     = rtrim( $parts[ $key ], '%' );
 					$$variable = (int) $value . $ending;
 				}
 				$classes = '';
 			}
 		}
 
-		return sprintf( '<iframe class="%s" width="%s" height="%s" src="%s" frameborder="0"></iframe>',
+		return sprintf(
+			'<iframe class="%s" width="%s" height="%s" src="%s" frameborder="0"></iframe>',
 			esc_attr( $classes ),
 			esc_attr( $width ),
 			esc_attr( $height ),

--- a/inc/shortcodes/class-soundcloud.php
+++ b/inc/shortcodes/class-soundcloud.php
@@ -6,33 +6,33 @@ class SoundCloud extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'SoundCloud', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-soundcloud.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'SoundCloud', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-soundcloud.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the SoundCloud track.', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the SoundCloud track.', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Type', 'shortcake-bakery' ),
-					'attr'         => 'type',
-					'type'         => 'select',
-					'options'      => array(
-						'simple'   => esc_html__( 'Simple', 'shortcake-bakery' ),
-						'visual'   => esc_html__( 'Visual', 'shortcake-bakery' ),
-						),
+					'label'   => esc_html__( 'Type', 'shortcake-bakery' ),
+					'attr'    => 'type',
+					'type'    => 'select',
+					'options' => array(
+						'simple' => esc_html__( 'Simple', 'shortcake-bakery' ),
+						'visual' => esc_html__( 'Visual', 'shortcake-bakery' ),
 					),
+				),
 				array(
-					'label'        => esc_html__( 'Autoplay', 'shortcake-bakery' ),
-					'attr'         => 'autoplay',
-					'type'         => 'select',
-					'options'      => array(
-						'0'        => esc_html__( 'No', 'shortcake-bakery' ),
-						'1'        => esc_html__( 'Yes', 'shortcake-bakery' ),
-						),
+					'label'   => esc_html__( 'Autoplay', 'shortcake-bakery' ),
+					'attr'    => 'autoplay',
+					'type'    => 'select',
+					'options' => array(
+						'0' => esc_html__( 'No', 'shortcake-bakery' ),
+						'1' => esc_html__( 'Yes', 'shortcake-bakery' ),
 					),
+				),
 			),
 		);
 	}
@@ -52,8 +52,8 @@ class SoundCloud extends Shortcode {
 				if ( empty( $args['url'] ) ) {
 					continue;
 				}
-				$type = ! empty( $args['visual'] ) && 'true' === $args['visual'] ? 'visual' : 'simple';
-				$autoplay = ! empty( $args['auto_play'] ) && 'true' === $args['auto_play'] ? '1' : '0';
+				$type                              = ! empty( $args['visual'] ) && 'true' === $args['visual'] ? 'visual' : 'simple';
+				$autoplay                          = ! empty( $args['auto_play'] ) && 'true' === $args['auto_play'] ? '1' : '0';
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $args['url'] ) . '" type="' . $type . '" autoplay="' . $autoplay . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -71,10 +71,10 @@ class SoundCloud extends Shortcode {
 
 		// Use the track URL in the API request. It will be redirected to the proper track ID
 		$embed_url = 'https://w.soundcloud.com/player/?url=' . rawurlencode( $attrs['url'] );
-		$height = 166;
+		$height    = 166;
 		if ( ! empty( $attrs['type'] ) && 'visual' === $attrs['type'] ) {
 			$embed_url = add_query_arg( 'visual', 'true', $embed_url );
-			$height = 450;
+			$height    = 450;
 		}
 		if ( ! empty( $attrs['autoplay'] ) ) {
 			$embed_url = add_query_arg( 'auto_play', 'true', $embed_url );

--- a/inc/shortcodes/class-twitter.php
+++ b/inc/shortcodes/class-twitter.php
@@ -6,14 +6,14 @@ class Twitter extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Twitter', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-twitter.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Twitter', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-twitter.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to a tweet', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to a tweet', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -27,7 +27,7 @@ class Twitter extends Shortcode {
 
 		$needle = '#<blockquote class="twitter-(tweet|video).+<a href="(https://twitter\.com/[^/]+/status/[^/]+)">.+(?=</blockquote>)</blockquote>\n?<script[^>]+src="//platform\.twitter\.com/widgets\.js"[^>]+></script>#';
 		if ( preg_match_all( $needle, $content, $matches ) ) {
-			$replacements = array();
+			$replacements  = array();
 			$shortcode_tag = self::get_shortcode_tag();
 			foreach ( $matches[0] as $key => $value ) {
 				$replacements[ $value ] = '[' . $shortcode_tag . ' url="' . esc_url_raw( $matches[2][ $key ] ) . '"]';
@@ -51,7 +51,8 @@ class Twitter extends Shortcode {
 			return '';
 		}
 
-		return sprintf( '<blockquote class="twitter-tweet"><a href="%s">%s</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>',
+		return sprintf(
+			'<blockquote class="twitter-tweet"><a href="%s">%s</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>',
 			esc_url( $attrs['url'] ),
 			/* Translators: Tweet pretext. */
 			sprintf( esc_html__( 'Tweet from @%s', 'shortcake-bakery' ), $username )

--- a/inc/shortcodes/class-videoo.php
+++ b/inc/shortcodes/class-videoo.php
@@ -6,14 +6,14 @@ class Videoo extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Videoo', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/png/icon-videoo.png' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Videoo', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/png/icon-videoo.png' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'URL to the Videoo', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'URL to the Videoo', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -32,10 +32,10 @@ class Videoo extends Shortcode {
 		}
 
 		$parts = explode( '?', $attrs['url'] );
-		$url = array_shift( $parts );
-		$url = add_query_arg( 'embed', 1, $url );
-		$ret = '<script src="' . esc_url( $url ) . '"></script>';
-		$ret .= <<<EOT
+		$url   = array_shift( $parts );
+		$url   = add_query_arg( 'embed', 1, $url );
+		$ret   = '<script src="' . esc_url( $url ) . '"></script>';
+		$ret  .= <<<EOT
 <style type="text/css">
 /** Updated Fix for iphone 6 and 6 plus **/
 @media(max-width:480px) { div.videooContainer, iframe.videoo-widget-player { width: 100vw !important; max-width: 100% !important; } }
@@ -58,8 +58,8 @@ EOT;
 				if ( 'videoo.com' !== self::parse_url( $script->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
-				$path = self::parse_url( $script->attrs['src'], PHP_URL_PATH );
-				$url = sprintf( 'https://videoo.com%s', $path );
+				$path                              = self::parse_url( $script->attrs['src'], PHP_URL_PATH );
+				$url                               = sprintf( 'https://videoo.com%s', $path );
 				$replacements[ $script->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );

--- a/inc/shortcodes/class-vimeo.php
+++ b/inc/shortcodes/class-vimeo.php
@@ -6,14 +6,14 @@ class Vimeo extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Vimeo', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-vimeo.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Vimeo', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-vimeo.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full Vimeo URL', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full Vimeo URL', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -32,7 +32,7 @@ class Vimeo extends Shortcode {
 				if ( empty( $parts[1] ) ) {
 					continue;
 				}
-				$embed_id = $parts[1];
+				$embed_id                          = $parts[1];
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( 'https://vimeo.com/' . $embed_id ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -44,15 +44,15 @@ class Vimeo extends Shortcode {
 	public static function callback( $attrs, $content = '' ) {
 
 		$valid_hosts = array( 'www.vimeo.com', 'vimeo.com' );
-		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
+		$host        = self::parse_url( $attrs['url'], PHP_URL_HOST );
 		if ( empty( $attrs['url'] ) || ! in_array( $host, $valid_hosts, true ) ) {
 			return '';
 		}
 
 		// Video ID is always the first part of the path
-		$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
-		$parts = explode( '/', trim( $path, '/' ) );
-		$video_id = $parts[0];
+		$path      = self::parse_url( $attrs['url'], PHP_URL_PATH );
+		$parts     = explode( '/', trim( $path, '/' ) );
+		$video_id  = $parts[0];
 		$embed_url = 'https://player.vimeo.com/video/' . $video_id;
 		return sprintf( '<iframe class="shortcake-bakery-responsive" width="500" height="281" src="%s" frameborder="0" allowfullscreen></iframe>', esc_url( $embed_url ) );
 	}

--- a/inc/shortcodes/class-vine.php
+++ b/inc/shortcodes/class-vine.php
@@ -6,33 +6,33 @@ class Vine extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'Vine', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-vine.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'Vine', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-vine.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full URL to the Vine', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full URL to the Vine', 'shortcake-bakery' ),
 				),
 				array(
-					'label'        => esc_html__( 'Type', 'shortcake-bakery' ),
-					'attr'         => 'type',
-					'type'         => 'select',
-					'options'      => array(
+					'label'   => esc_html__( 'Type', 'shortcake-bakery' ),
+					'attr'    => 'type',
+					'type'    => 'select',
+					'options' => array(
 						'simple'   => esc_html__( 'Simple', 'shortcake-bakery' ),
 						'postcard' => esc_html__( 'Postcard', 'shortcake-bakery' ),
-						),
 					),
+				),
 				array(
-					'label'        => esc_html__( 'Autoplay audio', 'shortcake-bakery' ),
-					'attr'         => 'autoplay',
-					'type'         => 'select',
-					'options'      => array(
-						'0'        => esc_html__( 'No', 'shortcake-bakery' ),
-						'1'        => esc_html__( 'Yes', 'shortcake-bakery' ),
-						),
+					'label'   => esc_html__( 'Autoplay audio', 'shortcake-bakery' ),
+					'attr'    => 'autoplay',
+					'type'    => 'select',
+					'options' => array(
+						'0' => esc_html__( 'No', 'shortcake-bakery' ),
+						'1' => esc_html__( 'Yes', 'shortcake-bakery' ),
 					),
+				),
 			),
 		);
 	}
@@ -47,7 +47,7 @@ class Vine extends Shortcode {
 				}
 				if ( preg_match( '#//vine.co/v/([^/]+)/embed/(simple|postcard)#', $iframe->attrs['src'], $matches ) ) {
 					$embed_id = $matches[1];
-					$type = $matches[2];
+					$type     = $matches[2];
 				} else {
 					continue;
 				}
@@ -78,9 +78,9 @@ class Vine extends Shortcode {
 		}
 
 		// ID is always the second part to the path
-		$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
-		$parts = explode( '/', trim( $path, '/' ) );
-		$embed_id = $parts[1];
+		$path      = self::parse_url( $attrs['url'], PHP_URL_PATH );
+		$parts     = explode( '/', trim( $path, '/' ) );
+		$embed_id  = $parts[1];
 		$embed_url = 'https://vine.co/v/' . $embed_id . '/embed/' . $type;
 		if ( ! empty( $attrs['autoplay'] ) ) {
 			$embed_url = add_query_arg( 'audio', '1', $embed_url );

--- a/inc/shortcodes/class-youtube.php
+++ b/inc/shortcodes/class-youtube.php
@@ -8,14 +8,14 @@ class YouTube extends Shortcode {
 
 	public static function get_shortcode_ui_args() {
 		return array(
-			'label'          => esc_html__( 'YouTube', 'shortcake-bakery' ),
-			'listItemImage'  => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-youtube.svg' ) . '" />',
-			'attrs'          => array(
+			'label'         => esc_html__( 'YouTube', 'shortcake-bakery' ),
+			'listItemImage' => '<img src="' . esc_url( SHORTCAKE_BAKERY_URL_ROOT . 'assets/images/svg/icon-youtube.svg' ) . '" />',
+			'attrs'         => array(
 				array(
-					'label'        => esc_html__( 'URL', 'shortcake-bakery' ),
-					'attr'         => 'url',
-					'type'         => 'text',
-					'description'  => esc_html__( 'Full YouTube URL', 'shortcake-bakery' ),
+					'label'       => esc_html__( 'URL', 'shortcake-bakery' ),
+					'attr'        => 'url',
+					'type'        => 'text',
+					'description' => esc_html__( 'Full YouTube URL', 'shortcake-bakery' ),
 				),
 			),
 		);
@@ -34,7 +34,7 @@ class YouTube extends Shortcode {
 				} else {
 					continue;
 				}
-				$replacement_url = 'https://www.youtube.com/watch?v=' . $embed_id;
+				$replacement_url                   = 'https://www.youtube.com/watch?v=' . $embed_id;
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $replacement_url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );

--- a/shortcake-bakery.php
+++ b/shortcake-bakery.php
@@ -39,8 +39,8 @@ spl_autoload_register( function( $class ) {
 	// Don't need "Shortcake_Bakery\"
 	array_shift( $parts );
 
-	$last = array_pop( $parts ); // File should be 'class-[...].php'
-	$last = 'class-' . $last . '.php';
+	$last    = array_pop( $parts ); // File should be 'class-[...].php'
+	$last    = 'class-' . $last . '.php';
 	$parts[] = $last;
 
 	$file = dirname( __FILE__ ) . '/inc/' . str_replace( '_', '-', strtolower( implode( $parts, '/' ) ) );


### PR DESCRIPTION
The version of phpcodesniffer required by WPCS (^3.0.1) conflicted with
the pinned version of phpcs in composer.json. SInce phpcs is registered
as a dependency of wpcs, it makes sense to not pin it to a specific
version.

Also, PHP 5.3 isn't around anymore, and doesn't need to be included in
the Travis matrix.